### PR TITLE
Fix capitalization

### DIFF
--- a/ProjectManagerClient.nuspec
+++ b/ProjectManagerClient.nuspec
@@ -24,6 +24,9 @@
             
             Deprecated 1 old APIs:
             * TaskMetadata.GetTaskMetadata
+			
+			Fixed capitalization for data schema models and API methods - the previous build caused some items
+			to be incorrectly lowercased when they were already in PascalCase form.
             
 
         </releaseNotes>

--- a/ProjectManagerClient.nuspec
+++ b/ProjectManagerClient.nuspec
@@ -2,53 +2,33 @@
 <package >
 	<metadata>
 		<id>ProjectManager.SDK</id>
-		<version>102.0.2887</version>
+		<version>102.0.2949</version>
 		<title>ProjectManager.SDK</title>
 		<authors>ProjectManager.com</authors>
 		<owners>ProjectManager.com, Inc.</owners>
 		<license type="file">docs/LICENSE</license>
 		<projectUrl>https://github.com/projectmgr/projectmanager-sdk-csharp</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<description> for DotNet</description>
+		<description>Software development kit for the ProjectManager.com API. for DotNet</description>
 		<icon>docs/logo.png</icon>
 		<readme>docs/README.md</readme>
 		<summary>ProjectManager API for DotNet</summary>
 		<releaseNotes>
-			# Patch notes for 102.0.2887
-			
-			Added XMLDOC to the automated SDK build-and-publish process.
-			
-            # Patch notes for 102.0.2886
+            # Patch notes for 102.0.2949
             
-            These patch notes summarize the changes from version 99.0.2550.
+            These patch notes summarize the changes from version 102.0.2886.
             
-            Added 8 new APIs:
-            * File.DeleteFile (DELETE /api/data/files/{fileId})
-            * Holiday.QueryResourceHolidays (GET /api/data/holidays/resource)
-            * Holiday.QueryCountryHolidays (GET /api/data/holidays/country)
-            * Holiday.QueryGlobalHolidays (GET /api/data/holidays/global)
-            * IntegrationProvider.DisconnectUserIntegrationProviderConnection (DELETE /api/data/integrations/providers/{providerId}/user-connection)
-            * NptFiles.UploadFileToNonProjectTasks (POST /api/data/non-project-tasks/{taskId}/files)
-            * TaskMetadata.AddMetadata (PUT /api/data/tasks/{taskId}/metadata)
-            * TaskMetadata.GetTasksByProjectIdAndForeignKeyId (GET /api/data/projects/{projectId}/tasks/metadata)
+            Added 2 new APIs:
+            * Changeset.RetrieveChangesetsByProjectID (GET /api/data/changesets/{projectId}/changesets)
+            * Project.DeleteProject (DELETE /api/data/projects/{projectId})
             
-            Changes to existing APIs:
-            * Discussion.CreateTaskComments changed [body].Value.DataType from DiscussionCommentCreateDto to DiscussionCreateDto
-            * Discussion.CreateTaskComments changed [body].Value.DataTypeRef from /docs/discussioncommentcreatedto to /docs/discussioncreatedto
-            * Project.QueryProjects removed query parameter `$select`
-            * Resource.QueryResources removed query parameter `$select`
-            * ResourceSkill.RetrieveResourceSkills removed query parameter `$select`
-            * ResourceTeam.RetrieveResourceTeams removed query parameter `$select`
-            * Tag.QueryTags removed query parameter `$select`
-            * Task.QueryTasks removed query parameter `$select`
-            * TaskField.QueryTaskFields removed query parameter `$select`
-            * TaskField.QueryTaskFieldValues removed query parameter `$select`
-            * Timesheet.QueryTimesheets removed query parameter `$select`
+            Deprecated 1 old APIs:
+            * TaskMetadata.GetTaskMetadata
             
 
         </releaseNotes>
 		<copyright>Copyright 2023 - 2024</copyright>
-    	<tags></tags>
+    	<tags>projectmanager project management task tracking projects tasks</tags>
 		<repository type="git" url="https://github.com/projectmgr/projectmanager-sdk-csharp" />
 		<dependencies>
 			<group targetFramework=".NETStandard2.0">

--- a/src/Clients/ApiKeyClient.cs
+++ b/src/Clients/ApiKeyClient.cs
@@ -90,7 +90,7 @@ namespace ProjectManager.SDK.Clients
         ///
         /// </summary>
         /// <param name="id">The unique identifier of the API key to revoke</param>
-        public async Task<AstroResult<string>> RevokeApiKey(Guid id)
+        public async Task<AstroResult<string>> RevokeAPIKey(Guid id)
         {
             var url = $"/api/data/api-keys/{id}/revoke";
             return await _client.Request<string>(HttpMethod.Delete, url, null, null, null);

--- a/src/Clients/ChangesetClient.cs
+++ b/src/Clients/ChangesetClient.cs
@@ -69,5 +69,23 @@ namespace ProjectManager.SDK.Clients
             var url = $"/api/data/changesets/{changeSetId}/poll";
             return await _client.Request<ChangesetGetResponseDto>(HttpMethod.Get, url, null, null, null);
         }
+
+        /// <summary>
+        /// Retrieve Changesets by Project ID
+        ///
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <param name="version"></param>
+        /// <param name="page"></param>
+        /// <param name="take"></param>
+        public async Task<AstroResult<ChangeSetResponseDto[]>> RetrieveChangesetsByProjectID(Guid projectId, int? version = null, int? page = null, int? take = null)
+        {
+            var url = $"/api/data/changesets/{projectId}/changesets";
+            var options = new Dictionary<string, object>();
+            if (version != null) { options["version"] = version; }
+            if (page != null) { options["page"] = page; }
+            if (take != null) { options["take"] = take; }
+            return await _client.Request<ChangeSetResponseDto[]>(HttpMethod.Get, url, options, null, null);
+        }
     }
 }

--- a/src/Clients/ProjectClient.cs
+++ b/src/Clients/ProjectClient.cs
@@ -102,5 +102,21 @@ namespace ProjectManager.SDK.Clients
             var url = $"/api/data/projects/{projectId}";
             return await _client.Request<string>(HttpMethod.Put, url, null, body, null);
         }
+
+        /// <summary>
+        /// Delete a project based on the details provided.
+        ///
+        /// A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks represent individual items of work that team members must complete.  The sum total of Tasks within a Project represents the work to be completed for that Project.
+        ///
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project to delete</param>
+        /// <param name="hardDelete">Hard delete project true or false</param>
+        public async Task<AstroResult<string>> DeleteProject(Guid projectId, bool? hardDelete = null)
+        {
+            var url = $"/api/data/projects/{projectId}";
+            var options = new Dictionary<string, object>();
+            if (hardDelete != null) { options["hardDelete"] = hardDelete; }
+            return await _client.Request<string>(HttpMethod.Delete, url, options, null, null);
+        }
     }
 }

--- a/src/Clients/ProjectFieldClient.cs
+++ b/src/Clients/ProjectFieldClient.cs
@@ -85,7 +85,7 @@ namespace ProjectManager.SDK.Clients
         /// <param name="projectId">The unique identifier of the Project that contains this ProjectField</param>
         /// <param name="fieldId">The unique identifier or short ID of this ProjectField</param>
         /// <param name="body">The new information for this ProjectField</param>
-        public async Task<AstroResult<string>> UpdateProjectfieldValue(Guid projectId, string fieldId, UpdateProjectFieldValueDto body)
+        public async Task<AstroResult<string>> UpdateProjectFieldValue(Guid projectId, string fieldId, UpdateProjectFieldValueDto body)
         {
             var url = $"/api/data/projects/{projectId}/fields/{fieldId}";
             return await _client.Request<string>(HttpMethod.Put, url, null, body, null);
@@ -99,7 +99,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project of the value to retrieve</param>
         /// <param name="fieldId">The unique identifier or short ID of the ProjectField of the value to retrieve</param>
-        public async Task<AstroResult<ProjectFieldValueDto>> RetrieveProjectfieldValue(Guid projectId, string fieldId)
+        public async Task<AstroResult<ProjectFieldValueDto>> RetrieveProjectFieldValue(Guid projectId, string fieldId)
         {
             var url = $"/api/data/projects/{projectId}/fields/{fieldId}";
             return await _client.Request<ProjectFieldValueDto>(HttpMethod.Get, url, null, null, null);
@@ -112,7 +112,7 @@ namespace ProjectManager.SDK.Clients
         ///
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for which we want ProjectField values</param>
-        public async Task<AstroResult<ProjectFieldValueDto[]>> RetrieveAllProjectfieldValues(Guid projectId)
+        public async Task<AstroResult<ProjectFieldValueDto[]>> RetrieveAllProjectFieldValues(Guid projectId)
         {
             var url = $"/api/data/projects/{projectId}/fields";
             return await _client.Request<ProjectFieldValueDto[]>(HttpMethod.Get, url, null, null, null);

--- a/src/Clients/TaskAssigneeClient.cs
+++ b/src/Clients/TaskAssigneeClient.cs
@@ -62,7 +62,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task to add or update an assignment</param>
         /// <param name="body">List of Assignee data</param>
-        public async Task<AstroResult<ChangeSetStatusDto>> CreateOrUpdateTaskassignee(Guid taskId, AssigneeUpsertDto[] body)
+        public async Task<AstroResult<ChangeSetStatusDto>> CreateOrUpdateTaskAssignee(Guid taskId, AssigneeUpsertDto[] body)
         {
             var url = $"/api/data/tasks/{taskId}/assignees";
             return await _client.Request<ChangeSetStatusDto>(HttpMethod.Put, url, null, body, null);

--- a/src/Clients/TaskFieldClient.cs
+++ b/src/Clients/TaskFieldClient.cs
@@ -109,7 +109,7 @@ namespace ProjectManager.SDK.Clients
         ///
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we want TaskField values</param>
-        public async Task<AstroResult<TaskFieldValueDto[]>> RetrieveAllTaskfieldValues(Guid taskId)
+        public async Task<AstroResult<TaskFieldValueDto[]>> RetrieveAllTaskFieldValues(Guid taskId)
         {
             var url = $"/api/data/tasks/{taskId}/fields/values";
             return await _client.Request<TaskFieldValueDto[]>(HttpMethod.Get, url, null, null, null);

--- a/src/Clients/TaskMetadataClient.cs
+++ b/src/Clients/TaskMetadataClient.cs
@@ -55,14 +55,7 @@ namespace ProjectManager.SDK.Clients
             return await _client.Request<string>(HttpMethod.Put, url, options, body, null);
         }
 
-        /// <summary>
-        /// Retrieve metadata about tasks for a project
-        /// </summary>
-        /// <param name="projectId">The unique ID of the project</param>
-        /// <param name="foreignKey">The foreign key of the project</param>
-        /// <param name="isSystem">A flag indicating whether this is a system call</param>
-        /// <returns></returns>
-        public async Task<AstroResult<TaskMetadataSearchDto[]>> GetTasksByProjectIdAndForeignKeyId(Guid projectId, string foreignKey = null, bool? isSystem = null)
+        public async Task<AstroResult<TaskMetadataSearchDto[]>> GetTasksByProjectIDAndForeignKeyID(Guid projectId, string foreignKey = null, bool? isSystem = null)
         {
             var url = $"/api/data/projects/{projectId}/tasks/metadata";
             var options = new Dictionary<string, object>();

--- a/src/Clients/TaskStatusClient.cs
+++ b/src/Clients/TaskStatusClient.cs
@@ -59,7 +59,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for the new TaskStatus</param>
         /// <param name="body">Information about the new TaskStatus level to create within this Project</param>
-        public async Task<AstroResult<TaskStatusDto>> CreateTaskstatus(Guid projectId, TaskStatusCreateDto body)
+        public async Task<AstroResult<TaskStatusDto>> CreateTaskStatus(Guid projectId, TaskStatusCreateDto body)
         {
             var url = $"/api/data/projects/{projectId}/tasks/statuses";
             return await _client.Request<TaskStatusDto>(HttpMethod.Post, url, null, body, null);
@@ -73,7 +73,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for the new TaskStatus</param>
         /// <param name="body">Information about the existing TaskStatus level to update within this Project</param>
-        public async Task<AstroResult<TaskStatusDto>> UpdateTaskstatus(Guid projectId, TaskStatusUpdateDto body)
+        public async Task<AstroResult<TaskStatusDto>> UpdateTaskStatus(Guid projectId, TaskStatusUpdateDto body)
         {
             var url = $"/api/data/projects/{projectId}/tasks/statuses";
             return await _client.Request<TaskStatusDto>(HttpMethod.Put, url, null, body, null);
@@ -87,7 +87,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for the TaskStatus level to delete</param>
         /// <param name="taskStatusId">The Id of the TaskStatus level to be removed.</param>
-        public async Task<AstroResult<string>> DeleteTaskstatus(Guid projectId, Guid taskStatusId)
+        public async Task<AstroResult<string>> DeleteTaskStatus(Guid projectId, Guid taskStatusId)
         {
             var url = $"/api/data/projects/{projectId}/tasks/statuses/{taskStatusId}";
             return await _client.Request<string>(HttpMethod.Delete, url, null, null, null);

--- a/src/Clients/TaskTagClient.cs
+++ b/src/Clients/TaskTagClient.cs
@@ -46,7 +46,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we will replace TaskTags</param>
         /// <param name="body">The replacement list of TaskTags for this Task</param>
-        public async Task<AstroResult<ChangeSetStatusDto>> ReplaceTasktags(Guid taskId, NameDto[] body)
+        public async Task<AstroResult<ChangeSetStatusDto>> ReplaceTaskTags(Guid taskId, NameDto[] body)
         {
             var url = $"/api/data/tasks/{taskId}/tags";
             return await _client.Request<ChangeSetStatusDto>(HttpMethod.Post, url, null, body, null);
@@ -60,7 +60,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we will add TaskTags</param>
         /// <param name="body">The new TaskTags to add to this Task</param>
-        public async Task<AstroResult<ChangeSetStatusDto>> AddTasktagToTask(Guid taskId, NameDto[] body)
+        public async Task<AstroResult<ChangeSetStatusDto>> AddTaskTagToTask(Guid taskId, NameDto[] body)
         {
             var url = $"/api/data/tasks/{taskId}/tags";
             return await _client.Request<ChangeSetStatusDto>(HttpMethod.Put, url, null, body, null);
@@ -74,7 +74,7 @@ namespace ProjectManager.SDK.Clients
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we will remove existing TaskTags</param>
         /// <param name="body">The TaskTags to remove from this Task</param>
-        public async Task<AstroResult<ChangeSetStatusDto>> RemoveTasktagFromTask(Guid taskId, NameDto[] body)
+        public async Task<AstroResult<ChangeSetStatusDto>> RemoveTaskTagFromTask(Guid taskId, NameDto[] body)
         {
             var url = $"/api/data/tasks/{taskId}/tags";
             return await _client.Request<ChangeSetStatusDto>(HttpMethod.Delete, url, null, body, null);

--- a/src/Clients/TimesheetClient.cs
+++ b/src/Clients/TimesheetClient.cs
@@ -60,7 +60,7 @@ namespace ProjectManager.SDK.Clients
         /// <param name="filter">Filter the expression according to oData queries</param>
         /// <param name="orderby">Order collection by this field.</param>
         /// <param name="expand">Include related data in the response</param>
-        public async Task<AstroResult<TimesheetDto[]>> QueryTimesheets(int? top = null, int? skip = null, string filter = null, string orderby = null, string expand = null)
+        public async Task<AstroResult<TimesheetDto[]>> QueryTimeSheets(int? top = null, int? skip = null, string filter = null, string orderby = null, string expand = null)
         {
             var url = $"/api/data/timesheets";
             var options = new Dictionary<string, object>();

--- a/src/Clients/UserRoleClient.cs
+++ b/src/Clients/UserRoleClient.cs
@@ -44,7 +44,7 @@ namespace ProjectManager.SDK.Clients
         /// A UserRole is a name for a privilege level granted to a specific User.  The &#39;Global Admin&#39; UserRole is granted to the owner of the Workspace, and this UserRole cannot be changed. You can choose which UserRole applies to a User within your Workspace.
         ///
         /// </summary>
-        public async Task<AstroResult<UserRoleDto[]>> RetrieveUserroles()
+        public async Task<AstroResult<UserRoleDto[]>> RetrieveUserRoles()
         {
             var url = $"/api/data/users/roles";
             return await _client.Request<UserRoleDto[]>(HttpMethod.Get, url, null, null, null);

--- a/src/Enums.cs
+++ b/src/Enums.cs
@@ -21,14 +21,7 @@ namespace ProjectManager.SDK
     /// </summary>
     public static class DashboardTypeValues
     {
-        /// <summary>
-        /// The "My Summary" dashboard
-        /// </summary>
         public const string MySummary = "MySummary";
-        
-        /// <summary>
-        /// The portfolio summary dashboard
-        /// </summary>
         public const string PortfolioSummary = "PortfolioSummary";
     }
 
@@ -37,24 +30,9 @@ namespace ProjectManager.SDK
     /// </summary>
     public static class ProjectPermissionValues
     {
-        /// <summary>
-        /// Represents a guest user within the project
-        /// </summary>
         public const string Guest = "Guest";
-        
-        /// <summary>
-        /// Represents a collaborator who can make some changes to a project
-        /// </summary>
         public const string Collaborate = "Collaborate";
-        
-        /// <summary>
-        /// Represents an editor who can make most changes to a project
-        /// </summary>
         public const string Editor = "Editor";
-        
-        /// <summary>
-        /// Represents a manager who can make all changes to a project
-        /// </summary>
         public const string Manager = "Manager";
     }
 
@@ -63,24 +41,9 @@ namespace ProjectManager.SDK
     /// </summary>
     public static class StateValues
     {
-        /// <summary>
-        /// Indicates that work has not yet started
-        /// </summary>
         public const string NotStarted = "NotStarted";
-        
-        /// <summary>
-        /// Some work has started, but it is not yet completed
-        /// </summary>
         public const string InProgress = "InProgress";
-        
-        /// <summary>
-        /// Completed successfully
-        /// </summary>
         public const string Success = "Success";
-        
-        /// <summary>
-        /// Failed
-        /// </summary>
         public const string Fail = "Fail";
     }
 }

--- a/src/IProjectManagerClient.cs
+++ b/src/IProjectManagerClient.cs
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    102.0.2886
+ * @version    102.0.2949
  * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
  */
 

--- a/src/Interfaces/IApiKeyClient.cs
+++ b/src/Interfaces/IApiKeyClient.cs
@@ -67,6 +67,6 @@ namespace ProjectManager.SDK.Interfaces
         ///
         /// </summary>
         /// <param name="id">The unique identifier of the API key to revoke</param>
-        Task<AstroResult<string>> RevokeApiKey(Guid id);
+        Task<AstroResult<string>> RevokeAPIKey(Guid id);
     }
 }

--- a/src/Interfaces/IChangesetClient.cs
+++ b/src/Interfaces/IChangesetClient.cs
@@ -50,5 +50,15 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="changeSetId">The unique ID number of the Changeset to retrieve</param>
         Task<AstroResult<ChangesetGetResponseDto>> RetrieveCompletedChangeset(Guid changeSetId);
+
+        /// <summary>
+        /// Retrieve Changesets by Project ID
+        ///
+        /// </summary>
+        /// <param name="projectId"></param>
+        /// <param name="version"></param>
+        /// <param name="page"></param>
+        /// <param name="take"></param>
+        Task<AstroResult<ChangeSetResponseDto[]>> RetrieveChangesetsByProjectID(Guid projectId, int? version = null, int? page = null, int? take = null);
     }
 }

--- a/src/Interfaces/IProjectClient.cs
+++ b/src/Interfaces/IProjectClient.cs
@@ -69,5 +69,15 @@ namespace ProjectManager.SDK.Interfaces
         /// <param name="projectId">The unique identifier of the Project to update</param>
         /// <param name="body">All non-null fields in this object will replace previous data within the Project</param>
         Task<AstroResult<string>> UpdateProject(Guid projectId, ProjectUpdateDto body);
+
+        /// <summary>
+        /// Delete a project based on the details provided.
+        ///
+        /// A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks represent individual items of work that team members must complete.  The sum total of Tasks within a Project represents the work to be completed for that Project.
+        ///
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project to delete</param>
+        /// <param name="hardDelete">Hard delete project true or false</param>
+        Task<AstroResult<string>> DeleteProject(Guid projectId, bool? hardDelete = null);
     }
 }

--- a/src/Interfaces/IProjectFieldClient.cs
+++ b/src/Interfaces/IProjectFieldClient.cs
@@ -62,7 +62,7 @@ namespace ProjectManager.SDK.Interfaces
         /// <param name="projectId">The unique identifier of the Project that contains this ProjectField</param>
         /// <param name="fieldId">The unique identifier or short ID of this ProjectField</param>
         /// <param name="body">The new information for this ProjectField</param>
-        Task<AstroResult<string>> UpdateProjectfieldValue(Guid projectId, string fieldId, UpdateProjectFieldValueDto body);
+        Task<AstroResult<string>> UpdateProjectFieldValue(Guid projectId, string fieldId, UpdateProjectFieldValueDto body);
 
         /// <summary>
         /// Retrieves the current ProjectField value for a particular Project and ProjectField.
@@ -72,7 +72,7 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project of the value to retrieve</param>
         /// <param name="fieldId">The unique identifier or short ID of the ProjectField of the value to retrieve</param>
-        Task<AstroResult<ProjectFieldValueDto>> RetrieveProjectfieldValue(Guid projectId, string fieldId);
+        Task<AstroResult<ProjectFieldValueDto>> RetrieveProjectFieldValue(Guid projectId, string fieldId);
 
         /// <summary>
         /// Retrieves all ProjectField values for a particular Project.
@@ -81,6 +81,6 @@ namespace ProjectManager.SDK.Interfaces
         ///
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for which we want ProjectField values</param>
-        Task<AstroResult<ProjectFieldValueDto[]>> RetrieveAllProjectfieldValues(Guid projectId);
+        Task<AstroResult<ProjectFieldValueDto[]>> RetrieveAllProjectFieldValues(Guid projectId);
     }
 }

--- a/src/Interfaces/ITaskAssigneeClient.cs
+++ b/src/Interfaces/ITaskAssigneeClient.cs
@@ -47,7 +47,7 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task to add or update an assignment</param>
         /// <param name="body">List of Assignee data</param>
-        Task<AstroResult<ChangeSetStatusDto>> CreateOrUpdateTaskassignee(Guid taskId, AssigneeUpsertDto[] body);
+        Task<AstroResult<ChangeSetStatusDto>> CreateOrUpdateTaskAssignee(Guid taskId, AssigneeUpsertDto[] body);
 
         /// <summary>
         /// Remove one or more TaskAssignees from a Task.

--- a/src/Interfaces/ITaskFieldClient.cs
+++ b/src/Interfaces/ITaskFieldClient.cs
@@ -76,7 +76,7 @@ namespace ProjectManager.SDK.Interfaces
         ///
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we want TaskField values</param>
-        Task<AstroResult<TaskFieldValueDto[]>> RetrieveAllTaskfieldValues(Guid taskId);
+        Task<AstroResult<TaskFieldValueDto[]>> RetrieveAllTaskFieldValues(Guid taskId);
 
         /// <summary>
         /// Retrieve a list of TaskFieldValues that match an [OData formatted query](https://www.odata.org/).

--- a/src/Interfaces/ITaskMetadataClient.cs
+++ b/src/Interfaces/ITaskMetadataClient.cs
@@ -37,13 +37,6 @@ namespace ProjectManager.SDK.Interfaces
         /// <param name="body">The metadata</param>
         Task<AstroResult<string>> AddMetadata(Guid taskId, TaskMetadataUpdateDto body, bool? isSystem = null, bool? isOverride = null);
 
-        /// <summary>
-        /// Retrieve metadata about tasks for a project
-        /// </summary>
-        /// <param name="projectId">The unique ID of the project</param>
-        /// <param name="foreignKey">The foreign key of the project</param>
-        /// <param name="isSystem">A flag indicating whether this is a system call</param>
-        /// <returns></returns>
-        Task<AstroResult<TaskMetadataSearchDto[]>> GetTasksByProjectIdAndForeignKeyId(Guid projectId, string foreignKey = null, bool? isSystem = null);
+        Task<AstroResult<TaskMetadataSearchDto[]>> GetTasksByProjectIDAndForeignKeyID(Guid projectId, string foreignKey = null, bool? isSystem = null);
     }
 }

--- a/src/Interfaces/ITaskStatusClient.cs
+++ b/src/Interfaces/ITaskStatusClient.cs
@@ -44,7 +44,7 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for the new TaskStatus</param>
         /// <param name="body">Information about the new TaskStatus level to create within this Project</param>
-        Task<AstroResult<TaskStatusDto>> CreateTaskstatus(Guid projectId, TaskStatusCreateDto body);
+        Task<AstroResult<TaskStatusDto>> CreateTaskStatus(Guid projectId, TaskStatusCreateDto body);
 
         /// <summary>
         /// Updates an existing TaskStatus level for a specific Project within your Workspace.
@@ -54,7 +54,7 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for the new TaskStatus</param>
         /// <param name="body">Information about the existing TaskStatus level to update within this Project</param>
-        Task<AstroResult<TaskStatusDto>> UpdateTaskstatus(Guid projectId, TaskStatusUpdateDto body);
+        Task<AstroResult<TaskStatusDto>> UpdateTaskStatus(Guid projectId, TaskStatusUpdateDto body);
 
         /// <summary>
         /// The endpoint is used to delete a TaskStatus.
@@ -64,6 +64,6 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="projectId">The unique identifier of the Project for the TaskStatus level to delete</param>
         /// <param name="taskStatusId">The Id of the TaskStatus level to be removed.</param>
-        Task<AstroResult<string>> DeleteTaskstatus(Guid projectId, Guid taskStatusId);
+        Task<AstroResult<string>> DeleteTaskStatus(Guid projectId, Guid taskStatusId);
     }
 }

--- a/src/Interfaces/ITaskTagClient.cs
+++ b/src/Interfaces/ITaskTagClient.cs
@@ -35,7 +35,7 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we will replace TaskTags</param>
         /// <param name="body">The replacement list of TaskTags for this Task</param>
-        Task<AstroResult<ChangeSetStatusDto>> ReplaceTasktags(Guid taskId, NameDto[] body);
+        Task<AstroResult<ChangeSetStatusDto>> ReplaceTaskTags(Guid taskId, NameDto[] body);
 
         /// <summary>
         /// Add one or more new TaskTags to a Task.
@@ -45,7 +45,7 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we will add TaskTags</param>
         /// <param name="body">The new TaskTags to add to this Task</param>
-        Task<AstroResult<ChangeSetStatusDto>> AddTasktagToTask(Guid taskId, NameDto[] body);
+        Task<AstroResult<ChangeSetStatusDto>> AddTaskTagToTask(Guid taskId, NameDto[] body);
 
         /// <summary>
         /// Removes one or more existing TaskTags from a Task.
@@ -55,6 +55,6 @@ namespace ProjectManager.SDK.Interfaces
         /// </summary>
         /// <param name="taskId">The unique identifier of the Task for which we will remove existing TaskTags</param>
         /// <param name="body">The TaskTags to remove from this Task</param>
-        Task<AstroResult<ChangeSetStatusDto>> RemoveTasktagFromTask(Guid taskId, NameDto[] body);
+        Task<AstroResult<ChangeSetStatusDto>> RemoveTaskTagFromTask(Guid taskId, NameDto[] body);
     }
 }

--- a/src/Interfaces/ITimesheetClient.cs
+++ b/src/Interfaces/ITimesheetClient.cs
@@ -45,7 +45,7 @@ namespace ProjectManager.SDK.Interfaces
         /// <param name="filter">Filter the expression according to oData queries</param>
         /// <param name="orderby">Order collection by this field.</param>
         /// <param name="expand">Include related data in the response</param>
-        Task<AstroResult<TimesheetDto[]>> QueryTimesheets(int? top = null, int? skip = null, string filter = null, string orderby = null, string expand = null);
+        Task<AstroResult<TimesheetDto[]>> QueryTimeSheets(int? top = null, int? skip = null, string filter = null, string orderby = null, string expand = null);
 
         /// <summary>
         /// Delete time entry by id.

--- a/src/Interfaces/IUserRoleClient.cs
+++ b/src/Interfaces/IUserRoleClient.cs
@@ -33,6 +33,6 @@ namespace ProjectManager.SDK.Interfaces
         /// A UserRole is a name for a privilege level granted to a specific User.  The &#39;Global Admin&#39; UserRole is granted to the owner of the Workspace, and this UserRole cannot be changed. You can choose which UserRole applies to a User within your Workspace.
         ///
         /// </summary>
-        Task<AstroResult<UserRoleDto[]>> RetrieveUserroles();
+        Task<AstroResult<UserRoleDto[]>> RetrieveUserRoles();
     }
 }

--- a/src/Models/ApiKeyCreateDto.cs
+++ b/src/Models/ApiKeyCreateDto.cs
@@ -29,6 +29,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Name of token
         /// </summary>
-        public string Tokenname { get; set; }
+        public string TokenName { get; set; }
     }
 }

--- a/src/Models/ApiKeyDto.cs
+++ b/src/Models/ApiKeyDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Created by user id
         /// </summary>
-        public Guid? Createdby { get; set; }
+        public Guid? CreatedBy { get; set; }
 
         /// <summary>
         /// Expires date
@@ -44,7 +44,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Bearer Key
         /// </summary>
-        public string Apikey { get; set; }
+        public string ApiKey { get; set; }
 
         /// <summary>
         /// Name of token

--- a/src/Models/AssigneeUpsertDto.cs
+++ b/src/Models/AssigneeUpsertDto.cs
@@ -36,6 +36,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The new amount of effort to assign for this Resource. This value is measured in minutes.
         /// </summary>
-        public int? Assignedeffort { get; set; }
+        public int? AssignedEffort { get; set; }
     }
 }

--- a/src/Models/AuthenticationDto.cs
+++ b/src/Models/AuthenticationDto.cs
@@ -34,6 +34,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Authenication scheme
         /// </summary>
-        public object Authscheme { get; set; }
+        public object AuthScheme { get; set; }
     }
 }

--- a/src/Models/ChangeSetResponseDto.cs
+++ b/src/Models/ChangeSetResponseDto.cs
@@ -1,0 +1,109 @@
+/***
+ * ProjectManager API for C#
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
+ */
+
+
+
+#pragma warning disable CS8618
+
+using System;
+
+namespace ProjectManager.SDK.Models
+{
+
+    /// <summary>
+    /// The project task change set
+    /// </summary>
+    public class ChangeSetResponseDto : ApiModel
+    {
+
+        /// <summary>
+        /// Project Changeset ID
+        /// </summary>
+        public int? ProjectChangeSetId { get; set; }
+
+        /// <summary>
+        /// The unique identifier of this Changeset
+        /// </summary>
+        public Guid? Id { get; set; }
+
+        /// <summary>
+        /// Project ID
+        /// </summary>
+        public Guid? ProjectId { get; set; }
+
+        /// <summary>
+        /// Task version
+        /// </summary>
+        public int? Version { get; set; }
+
+        /// <summary>
+        /// Created by GUID
+        /// </summary>
+        public Guid? CreateBy { get; set; }
+
+        /// <summary>
+        /// Created date
+        /// </summary>
+        public DateTime? CreateDate { get; set; }
+
+        /// <summary>
+        /// Change set action
+        /// </summary>
+        public string Actions { get; set; }
+
+        /// <summary>
+        /// Change set in json string
+        /// </summary>
+        public string ChangeSets { get; set; }
+
+        /// <summary>
+        /// Processed date
+        /// </summary>
+        public DateTime? ProcessDate { get; set; }
+
+        /// <summary>
+        /// If process was successful
+        /// </summary>
+        public bool? Success { get; set; }
+
+        /// <summary>
+        /// Error message
+        /// </summary>
+        public string Exception { get; set; }
+
+        /// <summary>
+        /// UI ID
+        /// </summary>
+        public Guid? ClientId { get; set; }
+
+        /// <summary>
+        /// Changeset JSON data
+        /// </summary>
+        public string JsonData { get; set; }
+
+        /// <summary>
+        /// Is change set from UNDO
+        /// </summary>
+        public bool? IsUndo { get; set; }
+
+        /// <summary>
+        /// The state of the changeset
+        /// </summary>
+        public int? State { get; set; }
+
+        /// <summary>
+        /// Business ID
+        /// </summary>
+        public Guid? BusinessId { get; set; }
+    }
+}

--- a/src/Models/ChangeSetStatusDto.cs
+++ b/src/Models/ChangeSetStatusDto.cs
@@ -29,7 +29,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique identifier of this Changeset
         /// </summary>
-        public Guid? Changesetid { get; set; }
+        public Guid? ChangeSetId { get; set; }
 
         /// <summary>
         /// The unique identifier of the entity affected by this Changeset.  For example, if this

--- a/src/Models/ConnectionSchemaDto.cs
+++ b/src/Models/ConnectionSchemaDto.cs
@@ -39,6 +39,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// This class contains the AuthScheme to use to authenticate with the Integration Provider.
         /// </summary>
-        public object Authscheme { get; set; }
+        public object AuthScheme { get; set; }
     }
 }

--- a/src/Models/CountryHolidayDto.cs
+++ b/src/Models/CountryHolidayDto.cs
@@ -41,6 +41,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Country id holiday associated to
         /// </summary>
-        public int? Countryid { get; set; }
+        public int? CountryId { get; set; }
     }
 }

--- a/src/Models/CreateProjectFieldDto.cs
+++ b/src/Models/CreateProjectFieldDto.cs
@@ -54,6 +54,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The short Id of this field - human readable identity
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
     }
 }

--- a/src/Models/CreateTaskFieldDto.cs
+++ b/src/Models/CreateTaskFieldDto.cs
@@ -59,6 +59,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The short Id of this field - human readable identity
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
     }
 }

--- a/src/Models/DashboardSettingCreateDto.cs
+++ b/src/Models/DashboardSettingCreateDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// User ID
         /// </summary>
-        public Guid? Userid { get; set; }
+        public Guid? UserId { get; set; }
 
         /// <summary>
         /// Either custom or one of DashboardType enum
@@ -44,6 +44,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// React grid layout configuration
         /// </summary>
-        public ReactGridLayoutDto Reactgridlayout { get; set; }
+        public ReactGridLayoutDto ReactGridLayout { get; set; }
     }
 }

--- a/src/Models/DashboardSettingDto.cs
+++ b/src/Models/DashboardSettingDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// User ID
         /// </summary>
-        public Guid? Userid { get; set; }
+        public Guid? UserId { get; set; }
 
         /// <summary>
         /// Either custom or one of DashboardType enum
@@ -44,6 +44,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// React grid layout configuration
         /// </summary>
-        public ReactGridLayoutDto Reactgridlayout { get; set; }
+        public ReactGridLayoutDto ReactGridLayout { get; set; }
     }
 }

--- a/src/Models/DiscussionCommentCreateResponseDto.cs
+++ b/src/Models/DiscussionCommentCreateResponseDto.cs
@@ -32,6 +32,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique identifier of the discussion comment created.
         /// </summary>
-        public Guid? Discussioncommentid { get; set; }
+        public Guid? DiscussionCommentId { get; set; }
     }
 }

--- a/src/Models/DiscussionCommentDto.cs
+++ b/src/Models/DiscussionCommentDto.cs
@@ -46,22 +46,22 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique ID of the resource that wrote this comment.
         /// </summary>
-        public Guid? Authorid { get; set; }
+        public Guid? AuthorId { get; set; }
 
         /// <summary>
         /// The unique ID of the resource that wrote this comment.
         /// </summary>
-        public string Authorname { get; set; }
+        public string AuthorName { get; set; }
 
         /// <summary>
         /// The timestamp when the comment was created.
         /// </summary>
-        public DateTime? Createdate { get; set; }
+        public DateTime? CreateDate { get; set; }
 
         /// <summary>
         /// The timestamp when the comment was modified, if it is different from the create date.
         /// </summary>
-        public DateTime? Modifydate { get; set; }
+        public DateTime? ModifyDate { get; set; }
 
         /// <summary>
         /// The list of emoji reactions to this discussion comment, if any.  This object will

--- a/src/Models/DiscussionCommentFileDto.cs
+++ b/src/Models/DiscussionCommentFileDto.cs
@@ -20,9 +20,6 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
-    /// <summary>
-    /// Discussion comment file
-    /// </summary>
     public class DiscussionCommentFileDto : ApiModel
     {
 

--- a/src/Models/DiscussionEmoji.cs
+++ b/src/Models/DiscussionEmoji.cs
@@ -34,6 +34,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The list of user IDs of the users who tagged these emoji
         /// </summary>
-        public Guid[] Userids { get; set; }
+        public Guid[] UserIds { get; set; }
     }
 }

--- a/src/Models/FileDto.cs
+++ b/src/Models/FileDto.cs
@@ -34,37 +34,37 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// If specified this file belongs to a project. The value is the id of  this project
         /// </summary>
-        public Guid? Projectid { get; set; }
+        public Guid? ProjectId { get; set; }
 
         /// <summary>
         /// If specified, the file has been associated with this task.
         /// </summary>
-        public Guid? Taskid { get; set; }
+        public Guid? TaskId { get; set; }
 
         /// <summary>
         /// The reference for who uploaded the file
         /// </summary>
-        public Guid? Ownerid { get; set; }
+        public Guid? OwnerId { get; set; }
 
         /// <summary>
         /// The UTC time the file was created.
         /// </summary>
-        public DateTime? Createddate { get; set; }
+        public DateTime? CreatedDate { get; set; }
 
         /// <summary>
         /// A reference to the folder
         /// </summary>
-        public Guid? Folderid { get; set; }
+        public Guid? FolderId { get; set; }
 
         /// <summary>
         /// The type of the file
         /// </summary>
-        public string Filetype { get; set; }
+        public string FileType { get; set; }
 
         /// <summary>
         /// A user friendly label for the file type
         /// </summary>
-        public string Filetypelabel { get; set; }
+        public string FileTypeLabel { get; set; }
 
         /// <summary>
         /// Size of the file in bytes
@@ -74,7 +74,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Path to download the file
         /// </summary>
-        public string Downloadpath { get; set; }
+        public string DownloadPath { get; set; }
 
         /// <summary>
         /// Is the file in the trash can
@@ -94,6 +94,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Id of owner of parent entity
         /// </summary>
-        public Guid? Entityownerid { get; set; }
+        public Guid? EntityOwnerId { get; set; }
     }
 }

--- a/src/Models/GetProjectFieldsResponseDto.cs
+++ b/src/Models/GetProjectFieldsResponseDto.cs
@@ -66,7 +66,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The entity type of the Field, either `projects` or `tasks`.
         /// </summary>
-        public string Entitytype { get; set; }
+        public string EntityType { get; set; }
 
         /// <summary>
         /// A list of options for use of this Field.  This is only valid if
@@ -81,6 +81,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The short Id of this field - human readable identity
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
     }
 }

--- a/src/Models/IntegrationAuthSetupDto.cs
+++ b/src/Models/IntegrationAuthSetupDto.cs
@@ -29,16 +29,16 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Master Connection for provider
         /// </summary>
-        public string Masterconnection { get; set; }
+        public string MasterConnection { get; set; }
 
         /// <summary>
         /// UserConnection for Provider.
         /// </summary>
-        public string Userconnection { get; set; }
+        public string UserConnection { get; set; }
 
         /// <summary>
         /// Master Connection scheme for Provider.
         /// </summary>
-        public object Masterconnectionschema { get; set; }
+        public object MasterConnectionSchema { get; set; }
     }
 }

--- a/src/Models/IntegrationCategoryDto.cs
+++ b/src/Models/IntegrationCategoryDto.cs
@@ -39,11 +39,11 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// A short identifier that uniquely identifies this Integration Category.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// A list of short identifiers for Integrations available within this Integration Category.
         /// </summary>
-        public string[] Integrationshortids { get; set; }
+        public string[] IntegrationShortIds { get; set; }
     }
 }

--- a/src/Models/IntegrationConnectionSchemeObjectDto.cs
+++ b/src/Models/IntegrationConnectionSchemeObjectDto.cs
@@ -39,6 +39,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Send to the client true/false
         /// </summary>
-        public bool? Sendtoclient { get; set; }
+        public bool? SendToClient { get; set; }
     }
 }

--- a/src/Models/IntegrationDto.cs
+++ b/src/Models/IntegrationDto.cs
@@ -45,7 +45,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// A short ID that uniquely identifies this Integration
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// True if this Integration allows multiple Instances.
@@ -53,7 +53,7 @@ namespace ProjectManager.SDK.Models
         /// An example of a multi-Instance Integration is one that can be connected to many
         /// different folders or channels within a remote application.
         /// </summary>
-        public bool? Ismultiinstance { get; set; }
+        public bool? IsMultiInstance { get; set; }
 
         /// <summary>
         /// Extra configuration metadata for this Instance.
@@ -63,7 +63,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The list of SKUS for this Integration.
         /// </summary>
-        public string[] Licenseskus { get; set; }
+        public string[] LicenseSkus { get; set; }
 
         /// <summary>
         /// For multi-Instance Integrations, this contains the list of IntegrationInstances.
@@ -83,6 +83,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// True if the integration is auto-enabled
         /// </summary>
-        public bool? Autoenabled { get; set; }
+        public bool? AutoEnabled { get; set; }
     }
 }

--- a/src/Models/IntegrationInstanceDto.cs
+++ b/src/Models/IntegrationInstanceDto.cs
@@ -35,36 +35,36 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// A short ID that uniquely identifies this IntegrationInstance
         /// </summary>
-        public string Integrationshortid { get; set; }
+        public string IntegrationShortId { get; set; }
 
         /// <summary>
         /// The unique identifier of the user who enabled this IntegrationInstance
         /// </summary>
-        public Guid? Enabledby { get; set; }
+        public Guid? EnabledBy { get; set; }
 
         /// <summary>
         /// Timestamp when this record was created
         /// </summary>
-        public DateTime? Createdate { get; set; }
+        public DateTime? CreateDate { get; set; }
 
         /// <summary>
         /// Timestamp when this record was most recently modified
         /// </summary>
-        public DateTime? Modifydate { get; set; }
+        public DateTime? ModifyDate { get; set; }
 
         /// <summary>
         /// The id of the project manager project this instance is related to
         /// </summary>
-        public Guid? Projectid { get; set; }
+        public Guid? ProjectId { get; set; }
 
         /// <summary>
         /// The identifier in the integration provider, could be a reference to a file, task, project.
         /// </summary>
-        public string Provideritemid { get; set; }
+        public string ProviderItemId { get; set; }
 
         /// <summary>
         /// The name of the item in the integration provider.
         /// </summary>
-        public string Provideritemname { get; set; }
+        public string ProviderItemName { get; set; }
     }
 }

--- a/src/Models/IntegrationProviderDto.cs
+++ b/src/Models/IntegrationProviderDto.cs
@@ -40,7 +40,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// A short ID that uniquely identifies this Provider.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// A short summary of this Provider and their service.
@@ -55,12 +55,12 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// A list of available license SKUs for this Provider.
         /// </summary>
-        public string[] Licenseskus { get; set; }
+        public string[] LicenseSkus { get; set; }
 
         /// <summary>
         /// A list of category IDs that this Provider exists within.
         /// </summary>
-        public string[] Categoryshortids { get; set; }
+        public string[] CategoryShortIds { get; set; }
 
         /// <summary>
         /// True if this Provider is available for use.
@@ -80,11 +80,11 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The list of available AuthSetup for this Provider.
         /// </summary>
-        public IntegrationAuthSetupDto Authsetup { get; set; }
+        public IntegrationAuthSetupDto AuthSetup { get; set; }
 
         /// <summary>
         /// Flag whether user/workspace needs to be setup in Workato
         /// </summary>
-        public bool? Createinworkato { get; set; }
+        public bool? CreateInWorkato { get; set; }
     }
 }

--- a/src/Models/LicenseDto.cs
+++ b/src/Models/LicenseDto.cs
@@ -35,12 +35,12 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The SKU code of this License, used for billing purposes.
         /// </summary>
-        public string Licensesku { get; set; }
+        public string LicenseSku { get; set; }
 
         /// <summary>
         /// The SKU code of the bundle of this License, used for billing purposes.
         /// </summary>
-        public string Bundlesku { get; set; }
+        public string BundleSku { get; set; }
 
         /// <summary>
         /// True if this license is optional.

--- a/src/Models/MasterConnectionSchemeDto.cs
+++ b/src/Models/MasterConnectionSchemeDto.cs
@@ -39,6 +39,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Send to the client true/false
         /// </summary>
-        public bool? Sendtoclient { get; set; }
+        public bool? SendToClient { get; set; }
     }
 }

--- a/src/Models/ProjectCreateAccessMemberDto.cs
+++ b/src/Models/ProjectCreateAccessMemberDto.cs
@@ -29,7 +29,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Member&#39;s id
         /// </summary>
-        public Guid? Userid { get; set; }
+        public Guid? UserId { get; set; }
 
         /// <summary>
         /// Member&#39;s role in the project

--- a/src/Models/ProjectCreateDto.cs
+++ b/src/Models/ProjectCreateDto.cs
@@ -44,46 +44,46 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique identifier of the folder of this project, or null if not assigned.
         /// </summary>
-        public Guid? Folderid { get; set; }
+        public Guid? FolderId { get; set; }
 
         /// <summary>
         /// If you wish to grant access to this Project to a selected list of people during creation,
         /// provide a list of ProjectMembers here.  If you do not specify anyone, this Project will
         /// be available to only yourself.
         /// </summary>
-        public ProjectCreateAccessDto Projectaccess { get; set; }
+        public ProjectCreateAccessDto ProjectAccess { get; set; }
 
         /// <summary>
         /// The unique identifier of the customer for this project, or null if not customer specific
         /// </summary>
-        public Guid? Customerid { get; set; }
+        public Guid? CustomerId { get; set; }
 
         /// <summary>
         /// The unique identifier of the manager of this project, or null if not assigned.
         /// </summary>
-        public Guid? Managerid { get; set; }
+        public Guid? ManagerId { get; set; }
 
         /// <summary>
         /// The unique identifier of the ChargeCode for this Project, if one has been selected.
         /// </summary>
-        public Guid? Chargecodeid { get; set; }
+        public Guid? ChargeCodeId { get; set; }
 
         /// <summary>
         /// The ProjectStatus chosen for this Project, if one has been selected.
         /// </summary>
-        public Guid? Statusid { get; set; }
+        public Guid? StatusId { get; set; }
 
         /// <summary>
         /// The ProjectPriority level of this Project, if one has been selected.
         /// </summary>
-        public Guid? Priorityid { get; set; }
+        public Guid? PriorityId { get; set; }
 
         /// <summary>
         /// The default hourly rate for work on this Project.  This rate will be used
         /// if an assignee working on this Project does not have an hourly rate configured
         /// in their profile.
         /// </summary>
-        public decimal? Hourlyrate { get; set; }
+        public decimal? HourlyRate { get; set; }
 
         /// <summary>
         /// The proposed budget for this Project.
@@ -96,7 +96,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// You can edit the StatusUpdate field on the Portfolio page of the application.
         /// </summary>
-        public string Statusupdate { get; set; }
+        public string StatusUpdate { get; set; }
 
         /// <summary>
         /// True if this Project is a template that will be reused as a framework
@@ -119,7 +119,7 @@ namespace ProjectManager.SDK.Models
         /// This field does not support custom templates.  You must choose from a list of
         /// ProjectManager-supplied templates.
         /// </summary>
-        public Guid? Templateid { get; set; }
+        public Guid? TemplateId { get; set; }
 
         /// <summary>
         /// The target planned completion date for this Project, or null if one has
@@ -128,7 +128,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Targetdate { get; set; }
+        public string TargetDate { get; set; }
 
         /// <summary>
         /// True if this Project is marked as favorite for current user

--- a/src/Models/ProjectDto.cs
+++ b/src/Models/ProjectDto.cs
@@ -49,7 +49,7 @@ namespace ProjectManager.SDK.Models
         /// name can be edited in the Project Settings page within the application
         /// and can be any text you wish.
         /// </summary>
-        public string Shortcode { get; set; }
+        public string ShortCode { get; set; }
 
         /// <summary>
         /// A short identifier that uniquely identifies this Project within your Workspace
@@ -63,7 +63,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This code is automatically assigned for you and cannot be changed.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// If this Project is grouped within a ProjectFolder, this contains the ProjectFolder information.
@@ -82,7 +82,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Startdate { get; set; }
+        public string StartDate { get; set; }
 
         /// <summary>
         /// The latest planned or actual finish date of tasks on the project.
@@ -91,7 +91,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Enddate { get; set; }
+        public string EndDate { get; set; }
 
         /// <summary>
         /// The target planned completion date for this Project, or null if one has
@@ -100,7 +100,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Targetdate { get; set; }
+        public string TargetDate { get; set; }
 
         /// <summary>
         /// A calculated field of the estimated date on which this Project is
@@ -112,7 +112,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedstartdate { get; set; }
+        public string PlannedStartDate { get; set; }
 
         /// <summary>
         /// A calculated field of the estimated date on which this Project is
@@ -124,7 +124,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedfinishdate { get; set; }
+        public string PlannedFinishDate { get; set; }
 
         /// <summary>
         /// A calculated field of the actual date on which this Project started.
@@ -135,7 +135,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Actualstartdate { get; set; }
+        public string ActualStartDate { get; set; }
 
         /// <summary>
         /// A calculated field of the actual date on which this Project finished.
@@ -146,7 +146,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Actualfinishdate { get; set; }
+        public string ActualFinishDate { get; set; }
 
         /// <summary>
         /// The ProjectPriority level of this Project, if defined.
@@ -156,7 +156,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The ChargeCode of this Project, if defined.
         /// </summary>
-        public ProjectChargeCodeDto Chargecode { get; set; }
+        public ProjectChargeCodeDto ChargeCode { get; set; }
 
         /// <summary>
         /// Information about the manager of this project, if one has been assigned.
@@ -178,7 +178,7 @@ namespace ProjectManager.SDK.Models
         /// if an assignee working on this Project does not have an hourly rate configured
         /// in their profile.
         /// </summary>
-        public decimal? Hourlyrate { get; set; }
+        public decimal? HourlyRate { get; set; }
 
         /// <summary>
         /// Contains an optional status update for Projects that can be used to summarize
@@ -186,7 +186,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// You can edit the StatusUpdate field on the Portfolio page of the application.
         /// </summary>
-        public string Statusupdate { get; set; }
+        public string StatusUpdate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when the Project was most recently modified.
@@ -194,7 +194,7 @@ namespace ProjectManager.SDK.Models
         /// This field is automatically determined by the system when this Project is modified
         /// and cannot be directly changed by the user.
         /// </summary>
-        public DateTime? Modifydate { get; set; }
+        public DateTime? ModifyDate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when the Project was created.
@@ -202,13 +202,13 @@ namespace ProjectManager.SDK.Models
         /// This field is automatically determined by the system when this Project is created
         /// and cannot be changed by the user.
         /// </summary>
-        public DateTime? Createdate { get; set; }
+        public DateTime? CreateDate { get; set; }
 
         /// <summary>
         /// True if this Project is a template that will be reused as a framework
         /// for future Projects.
         /// </summary>
-        public bool? Istemplate { get; set; }
+        public bool? IsTemplate { get; set; }
 
         /// <summary>
         /// True if this Project is marked as favorite for current user
@@ -219,7 +219,7 @@ namespace ProjectManager.SDK.Models
         /// The TemplateId that this project was created from.
         /// Will be null if no template was selected at project creation.
         /// </summary>
-        public Guid? Creationtemplateid { get; set; }
+        public Guid? CreationTemplateId { get; set; }
 
         /// <summary>
         /// The members of the project
@@ -229,7 +229,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Project fields array with values
         /// </summary>
-        public ProjectFieldValueDto[] Fieldvalues { get; set; }
+        public ProjectFieldValueDto[] FieldValues { get; set; }
 
         /// <summary>
         /// The list of files associated with this Project, if any.

--- a/src/Models/ProjectFieldValueDto.cs
+++ b/src/Models/ProjectFieldValueDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique Short Id of this Project Field.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The name of this Project Field.
@@ -60,11 +60,11 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Date and time (in UTC) that this TaskField was created.
         /// </summary>
-        public DateTime? Createddate { get; set; }
+        public DateTime? CreatedDate { get; set; }
 
         /// <summary>
         /// Date and time (in UTC) that this TaskField was last modified.
         /// </summary>
-        public DateTime? Modifieddate { get; set; }
+        public DateTime? ModifiedDate { get; set; }
     }
 }

--- a/src/Models/ProjectFileDto.cs
+++ b/src/Models/ProjectFileDto.cs
@@ -20,9 +20,6 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
-    /// <summary>
-    /// Project File
-    /// </summary>
     public class ProjectFileDto : ApiModel
     {
 

--- a/src/Models/ProjectFileTaskDto.cs
+++ b/src/Models/ProjectFileTaskDto.cs
@@ -20,9 +20,6 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
-    /// <summary>
-    /// A file attached to a project and task
-    /// </summary>
     public class ProjectFileTaskDto : ApiModel
     {
 
@@ -35,7 +32,7 @@ namespace ProjectManager.SDK.Models
         /// A short ID that can be used to refer to this Task.  This short ID is
         /// guaranteed to be unique within your Workspace.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The common name of this Task.

--- a/src/Models/ProjectManagerDto.cs
+++ b/src/Models/ProjectManagerDto.cs
@@ -44,6 +44,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Avatar&#39;s url
         /// </summary>
-        public string Avatarurl { get; set; }
+        public string AvatarUrl { get; set; }
     }
 }

--- a/src/Models/ProjectMemberDto.cs
+++ b/src/Models/ProjectMemberDto.cs
@@ -46,7 +46,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Avatar URL
         /// </summary>
-        public string Avatarurl { get; set; }
+        public string AvatarUrl { get; set; }
 
         /// <summary>
         /// The current permission of the user
@@ -61,6 +61,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Specifies the permissions that you can set against the project member. This changes based on who is logged in and the role they have.
         /// </summary>
-        public PermissionOptionsDto Permissionoptions { get; set; }
+        public PermissionOptionsDto PermissionOptions { get; set; }
     }
 }

--- a/src/Models/ProjectStatusDto.cs
+++ b/src/Models/ProjectStatusDto.cs
@@ -41,6 +41,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Is this a deleted status
         /// </summary>
-        public bool? Isdeleted { get; set; }
+        public bool? IsDeleted { get; set; }
     }
 }

--- a/src/Models/ProjectTemplateDto.cs
+++ b/src/Models/ProjectTemplateDto.cs
@@ -60,7 +60,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The preview image path for this ProjectTemplate.
         /// </summary>
-        public string Previewimage { get; set; }
+        public string PreviewImage { get; set; }
 
         /// <summary>
         /// The overall order of this ProjectTemplate.
@@ -75,11 +75,11 @@ namespace ProjectManager.SDK.Models
         /// Custom templates are Templates that have been created from existing
         /// Project definitions.
         /// </summary>
-        public bool? Iscustom { get; set; }
+        public bool? IsCustom { get; set; }
 
         /// <summary>
         /// The web default view of the template.
         /// </summary>
-        public string Defaultview { get; set; }
+        public string DefaultView { get; set; }
     }
 }

--- a/src/Models/ProjectUpdateDto.cs
+++ b/src/Models/ProjectUpdateDto.cs
@@ -48,48 +48,48 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Targetdate { get; set; }
+        public string TargetDate { get; set; }
 
         /// <summary>
         /// To move this Project into a ProjectFolder, set this to the unique identifier of the
         /// ProjectFolder.
         /// </summary>
-        public Guid? Folderid { get; set; }
+        public Guid? FolderId { get; set; }
 
         /// <summary>
         /// To assign this Project to a ProjectCustomer, set this to the unique identifier of the
         /// ProjectCustomer.
         /// </summary>
-        public Guid? Customerid { get; set; }
+        public Guid? CustomerId { get; set; }
 
         /// <summary>
         /// To assign this Project to a ProjectManager, set this to the unique identifier of the
         /// ProjectManager.
         /// </summary>
-        public Guid? Managerid { get; set; }
+        public Guid? ManagerId { get; set; }
 
         /// <summary>
         /// To set the ChargeCode for this Project, set this to the unique identifier of the
         /// ChargeCode to use for this Project.
         /// </summary>
-        public Guid? Chargecodeid { get; set; }
+        public Guid? ChargeCodeId { get; set; }
 
         /// <summary>
         /// To change the ProjectStatus of this Project, set this to the unique identifier of the
         /// ProjectStatus.
         /// </summary>
-        public Guid? Statusid { get; set; }
+        public Guid? StatusId { get; set; }
 
         /// <summary>
         /// To change the ProjectPriority of this Project, set this to the unique identifier of the
         /// ProjectPriority.
         /// </summary>
-        public Guid? Priorityid { get; set; }
+        public Guid? PriorityId { get; set; }
 
         /// <summary>
         /// To change the hourly rate of this Project, set this to the new amount.
         /// </summary>
-        public decimal? Hourlyrate { get; set; }
+        public decimal? HourlyRate { get; set; }
 
         /// <summary>
         /// To change the budget of this Project, set this to the new amount.
@@ -99,7 +99,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// To update the Project&#39;s status text, set this to the new status text.
         /// </summary>
-        public string Statusupdate { get; set; }
+        public string StatusUpdate { get; set; }
 
         /// <summary>
         /// Mark this project as favorite for the logged in user.

--- a/src/Models/ResourceCreateDto.cs
+++ b/src/Models/ResourceCreateDto.cs
@@ -35,14 +35,14 @@ namespace ProjectManager.SDK.Models
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Firstname { get; set; }
+        public string FirstName { get; set; }
 
         /// <summary>
         /// The last name of the person Resource.
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Lastname { get; set; }
+        public string LastName { get; set; }
 
         /// <summary>
         /// The email address of this Resource.
@@ -52,7 +52,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The basic hourly rate for this Resource.
         /// </summary>
-        public decimal? Hourlyrate { get; set; }
+        public decimal? HourlyRate { get; set; }
 
         /// <summary>
         /// The phone number associated with this Resource.
@@ -74,7 +74,7 @@ namespace ProjectManager.SDK.Models
         /// A text field indicating the country in which this Resource is located.
         /// This value must be one of the following: US, NZ, AU.
         /// </summary>
-        public string Countrycode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// Free-form text notes about this Resource.  You may use this field to store extra
@@ -87,16 +87,16 @@ namespace ProjectManager.SDK.Models
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public Guid? Roleid { get; set; }
+        public Guid? RoleId { get; set; }
 
         /// <summary>
         /// The list of ResourceTeams to which this Resource belongs.
         /// </summary>
-        public Guid[] Teamids { get; set; }
+        public Guid[] TeamIds { get; set; }
 
         /// <summary>
         /// The list of ResourceSkills possessed by this Resource.
         /// </summary>
-        public Guid[] Skillids { get; set; }
+        public Guid[] SkillIds { get; set; }
     }
 }

--- a/src/Models/ResourceDto.cs
+++ b/src/Models/ResourceDto.cs
@@ -40,14 +40,14 @@ namespace ProjectManager.SDK.Models
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Firstname { get; set; }
+        public string FirstName { get; set; }
 
         /// <summary>
         /// The last name of the person Resource.
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Lastname { get; set; }
+        public string LastName { get; set; }
 
         /// <summary>
         /// If this Resource is a person who can log on to ProjectManager.com, this value should be the email address of the
@@ -61,7 +61,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The basic hourly rate for this Resource.
         /// </summary>
-        public decimal? Hourlyrate { get; set; }
+        public decimal? HourlyRate { get; set; }
 
         /// <summary>
         /// The phone number associated with this Resource.
@@ -112,7 +112,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public DateTime? Onlinedatetime { get; set; }
+        public DateTime? OnlineDateTime { get; set; }
 
         /// <summary>
         /// The Role privileges associated with this Resource.
@@ -128,6 +128,6 @@ namespace ProjectManager.SDK.Models
         /// For personnel Resources, setting this value to False will make this user unable
         /// to access this Workspace.
         /// </summary>
-        public bool? Isactive { get; set; }
+        public bool? IsActive { get; set; }
     }
 }

--- a/src/Models/ResourceHolidayDto.cs
+++ b/src/Models/ResourceHolidayDto.cs
@@ -41,6 +41,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Resource id holoday associated to
         /// </summary>
-        public Guid? Resourceid { get; set; }
+        public Guid? ResourceId { get; set; }
     }
 }

--- a/src/Models/ResourceUpdateDto.cs
+++ b/src/Models/ResourceUpdateDto.cs
@@ -35,14 +35,14 @@ namespace ProjectManager.SDK.Models
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Firstname { get; set; }
+        public string FirstName { get; set; }
 
         /// <summary>
         /// The last name of the person Resource.
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Lastname { get; set; }
+        public string LastName { get; set; }
 
         /// <summary>
         /// The email address of this Resource.
@@ -54,7 +54,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The basic hourly rate for this Resource.
         /// </summary>
-        public decimal? Hourlyrate { get; set; }
+        public decimal? HourlyRate { get; set; }
 
         /// <summary>
         /// The phone number associated with this Resource.
@@ -76,7 +76,7 @@ namespace ProjectManager.SDK.Models
         /// A text field indicating the country in which this Resource is located.
         /// This value must be one of the following: US, NZ, AU.
         /// </summary>
-        public string Countrycode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// Free-form text notes about this Resource.  You may use this field to store extra
@@ -89,16 +89,16 @@ namespace ProjectManager.SDK.Models
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public Guid? Roleid { get; set; }
+        public Guid? RoleId { get; set; }
 
         /// <summary>
         /// The list of ResourceTeams to which this Resource belongs.
         /// </summary>
-        public Guid[] Teamids { get; set; }
+        public Guid[] TeamIds { get; set; }
 
         /// <summary>
         /// The list of ResourceSkills possessed by this Resource.
         /// </summary>
-        public Guid[] Skillids { get; set; }
+        public Guid[] SkillIds { get; set; }
     }
 }

--- a/src/Models/TaskAssigneeDto.cs
+++ b/src/Models/TaskAssigneeDto.cs
@@ -51,7 +51,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// True if this TaskAssignee is currently active with the Project.
         /// </summary>
-        public bool? Isactive { get; set; }
+        public bool? IsActive { get; set; }
 
         /// <summary>
         /// The color that will be used to represent this TaskAssignee visually.
@@ -67,26 +67,26 @@ namespace ProjectManager.SDK.Models
         ///
         /// For personnel TaskAssignees only.
         /// </summary>
-        public string Firstname { get; set; }
+        public string FirstName { get; set; }
 
         /// <summary>
         /// The last or family name of this TaskAssignee.
         ///
         /// For personnel TaskAssignees only.
         /// </summary>
-        public string Lastname { get; set; }
+        public string LastName { get; set; }
 
         /// <summary>
         /// A shortened version of the name of this TaskAssignee.  This is used in areas
         /// where the Initials are too short but the full name is too long.
         /// </summary>
-        public string Shortname { get; set; }
+        public string ShortName { get; set; }
 
         /// <summary>
         /// A link to an Avatar for this TaskAssignee.  Avatars are small images or representations
         /// that can be used to visually identify this TaskAssignee at a glance.
         /// </summary>
-        public string Avatarurl { get; set; }
+        public string AvatarUrl { get; set; }
 
         /// <summary>
         /// The email address for the resource. It can be empty if the resource does not have a login.
@@ -96,6 +96,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The allocated effort (in minutes) for this Task and Assignee.
         /// </summary>
-        public int? Allocatedeffort { get; set; }
+        public int? AllocatedEffort { get; set; }
     }
 }

--- a/src/Models/TaskCreateDto.cs
+++ b/src/Models/TaskCreateDto.cs
@@ -46,17 +46,17 @@ namespace ProjectManager.SDK.Models
         /// This value can be edited manually in the Gantt chart view of the application,
         /// or can be selected on the Task Detail page within the Kanban board.
         /// </summary>
-        public int? Percentcomplete { get; set; }
+        public int? PercentComplete { get; set; }
 
         /// <summary>
         /// The unique identifier of the TaskStatus for this Task
         /// </summary>
-        public Guid? Statusid { get; set; }
+        public Guid? StatusId { get; set; }
 
         /// <summary>
         /// A numerical value representing the Priority of this Task
         /// </summary>
-        public int? Priorityid { get; set; }
+        public int? PriorityId { get; set; }
 
         /// <summary>
         /// A list of unique identifiers of TaskAssignees to be assigned to this Task
@@ -68,41 +68,41 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedstartdate { get; set; }
+        public string PlannedStartDate { get; set; }
 
         /// <summary>
         /// The date when work on this Task is expected to complete.
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedfinishdate { get; set; }
+        public string PlannedFinishDate { get; set; }
 
         /// <summary>
         /// The planned duration (in minutes) for this Task.  Cannot be negative.
         /// </summary>
-        public int? Plannedduration { get; set; }
+        public int? PlannedDuration { get; set; }
 
         /// <summary>
         /// The planned effort (in minutes) for this Task.  Cannot be negative.
         /// </summary>
-        public int? Plannedeffort { get; set; }
+        public int? PlannedEffort { get; set; }
 
         /// <summary>
         /// The planned cost for this Task.  Cannot be negative.
         /// </summary>
-        public decimal? Plannedcost { get; set; }
+        public decimal? PlannedCost { get; set; }
 
         /// <summary>
         /// The date when work on this Task actually started, if known.
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Actualstartdate { get; set; }
+        public string ActualStartDate { get; set; }
 
         /// <summary>
         /// The actual cost of this Task to date, if known.
         /// </summary>
-        public decimal? Actualcost { get; set; }
+        public decimal? ActualCost { get; set; }
 
         /// <summary>
         /// Color theme definition for this task.

--- a/src/Models/TaskDto.cs
+++ b/src/Models/TaskDto.cs
@@ -46,7 +46,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique identifier of the Project to which this Task belongs.
         /// </summary>
-        public Guid? Projectid { get; set; }
+        public Guid? ProjectId { get; set; }
 
         /// <summary>
         /// The list of assignees who are to work on this Task, if any.
@@ -62,7 +62,7 @@ namespace ProjectManager.SDK.Models
         /// A short ID that can be used to refer to this Task.  This short ID is
         /// guaranteed to be unique within your Workspace.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The common name of this Task.
@@ -94,7 +94,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedstartdate { get; set; }
+        public string PlannedStartDate { get; set; }
 
         /// <summary>
         /// The date when work on this Task is expected to complete.
@@ -111,7 +111,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedfinishdate { get; set; }
+        public string PlannedFinishDate { get; set; }
 
         /// <summary>
         /// If set, this is the actual date when work began on the Task.
@@ -128,7 +128,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Actualstartdate { get; set; }
+        public string ActualStartDate { get; set; }
 
         /// <summary>
         /// If set, this is the actual date when work was completed on this Task.
@@ -145,17 +145,17 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Actualfinishdate { get; set; }
+        public string ActualFinishDate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when this Task was most recently modified.
         /// </summary>
-        public DateTime? Modifydate { get; set; }
+        public DateTime? ModifyDate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when this Task was created.
         /// </summary>
-        public DateTime? Createdate { get; set; }
+        public DateTime? CreateDate { get; set; }
 
         /// <summary>
         /// The numerical percentage, from 0-100, representing the percentage completion
@@ -165,7 +165,7 @@ namespace ProjectManager.SDK.Models
         /// This value can be edited manually in the Gantt chart view of the application,
         /// or can be selected on the Task Detail page within the Kanban board.
         /// </summary>
-        public int? Percentcomplete { get; set; }
+        public int? PercentComplete { get; set; }
 
         /// <summary>
         /// True if this Task is the parent of multiple Tasks underneath it.  A parent Task
@@ -175,12 +175,12 @@ namespace ProjectManager.SDK.Models
         /// You can create a summary Task in the Gantt chart view of the application by
         /// adding child tasks underneath a parent Task.
         /// </summary>
-        public bool? Issummary { get; set; }
+        public bool? IsSummary { get; set; }
 
         /// <summary>
         /// Return the priority of a task
         /// </summary>
-        public int? Priorityid { get; set; }
+        public int? PriorityId { get; set; }
 
         /// <summary>
         /// The WBS (Work Breakdown Structure) number for this task within the Gantt chart hierarchy.  See [What
@@ -201,27 +201,27 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The actual cost of this Task to date, if known.
         /// </summary>
-        public decimal? Actualcost { get; set; }
+        public decimal? ActualCost { get; set; }
 
         /// <summary>
         /// The planned cost for this Task.  Cannot be negative.
         /// </summary>
-        public decimal? Plannedcost { get; set; }
+        public decimal? PlannedCost { get; set; }
 
         /// <summary>
         /// The planned duration (in minutes) for this Task.
         /// </summary>
-        public int? Plannedduration { get; set; }
+        public int? PlannedDuration { get; set; }
 
         /// <summary>
         /// The planned effort (in minutes) for this Task.
         /// </summary>
-        public int? Plannedeffort { get; set; }
+        public int? PlannedEffort { get; set; }
 
         /// <summary>
         /// Task fields array with values
         /// </summary>
-        public TaskFieldValueDto[] Fieldvalues { get; set; }
+        public TaskFieldValueDto[] FieldValues { get; set; }
 
         /// <summary>
         /// The list of files associated with this Task, if any.

--- a/src/Models/TaskFieldDto.cs
+++ b/src/Models/TaskFieldDto.cs
@@ -69,7 +69,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The short Id of this TaskField - human readable identity
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The Project to which this TaskField belongs.
@@ -79,11 +79,11 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Date and time (in UTC) that this TaskField was created.
         /// </summary>
-        public DateTime? Createddate { get; set; }
+        public DateTime? CreatedDate { get; set; }
 
         /// <summary>
         /// Date and time (in UTC) that this TaskField was last modified.
         /// </summary>
-        public DateTime? Modifieddate { get; set; }
+        public DateTime? ModifiedDate { get; set; }
     }
 }

--- a/src/Models/TaskFieldProjectDto.cs
+++ b/src/Models/TaskFieldProjectDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The ShortId of this Project.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The common name of this Project.

--- a/src/Models/TaskFieldValueDto.cs
+++ b/src/Models/TaskFieldValueDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique Short Id of this TaskField.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The name of this Project Field.
@@ -60,12 +60,12 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Date and time (in UTC) that this TaskField was created.
         /// </summary>
-        public DateTime? Createddate { get; set; }
+        public DateTime? CreatedDate { get; set; }
 
         /// <summary>
         /// Date and time (in UTC) that this TaskField was last modified.
         /// </summary>
-        public DateTime? Modifieddate { get; set; }
+        public DateTime? ModifiedDate { get; set; }
 
         /// <summary>
         /// The Task to which this Value belongs.

--- a/src/Models/TaskFieldValueTaskDto.cs
+++ b/src/Models/TaskFieldValueTaskDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique Short Id of this Task.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The common name of this Task.

--- a/src/Models/TaskMetadataSearchDto.cs
+++ b/src/Models/TaskMetadataSearchDto.cs
@@ -34,7 +34,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Project ID
         /// </summary>
-        public Guid? Projectid { get; set; }
+        public Guid? ProjectId { get; set; }
 
         /// <summary>
         /// Customer or system metadata

--- a/src/Models/TaskProjectDto.cs
+++ b/src/Models/TaskProjectDto.cs
@@ -36,7 +36,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The ShortId of this Project.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The common name of this Project.

--- a/src/Models/TaskStatusDto.cs
+++ b/src/Models/TaskStatusDto.cs
@@ -36,7 +36,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique identifier of the Project to which this TaskStatus belongs.
         /// </summary>
-        public Guid? Projectid { get; set; }
+        public Guid? ProjectId { get; set; }
 
         /// <summary>
         /// The name of this TaskStatus.
@@ -52,6 +52,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// True if a Task in this TaskStatus is considered done.
         /// </summary>
-        public bool? Isdone { get; set; }
+        public bool? IsDone { get; set; }
     }
 }

--- a/src/Models/TaskTodoDto.cs
+++ b/src/Models/TaskTodoDto.cs
@@ -45,11 +45,11 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The timestamp in UTC when this object was created.
         /// </summary>
-        public DateTime? Createdate { get; set; }
+        public DateTime? CreateDate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when this object was last modified.
         /// </summary>
-        public DateTime? Modifydate { get; set; }
+        public DateTime? ModifyDate { get; set; }
     }
 }

--- a/src/Models/TaskUpdateDto.cs
+++ b/src/Models/TaskUpdateDto.cs
@@ -46,17 +46,17 @@ namespace ProjectManager.SDK.Models
         /// This value can be edited manually in the Gantt chart view of the application,
         /// or can be selected on the Task Detail page within the Kanban board.
         /// </summary>
-        public int? Percentcomplete { get; set; }
+        public int? PercentComplete { get; set; }
 
         /// <summary>
         /// The TaskStatus assigned to this Task.
         /// </summary>
-        public Guid? Statusid { get; set; }
+        public Guid? StatusId { get; set; }
 
         /// <summary>
         /// The unique identifier of the TaskPriority
         /// </summary>
-        public int? Priorityid { get; set; }
+        public int? PriorityId { get; set; }
 
         /// <summary>
         /// The date when work on this Task is planned to begin.
@@ -73,7 +73,7 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedstartdate { get; set; }
+        public string PlannedStartDate { get; set; }
 
         /// <summary>
         /// The date when work on this Task is expected to complete.
@@ -90,22 +90,22 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Plannedfinishdate { get; set; }
+        public string PlannedFinishDate { get; set; }
 
         /// <summary>
         /// The planned duration (in minutes) for this Task.  Cannot be negative.
         /// </summary>
-        public int? Plannedduration { get; set; }
+        public int? PlannedDuration { get; set; }
 
         /// <summary>
         /// The planned effort (in minutes) for this Task.  Cannot be negative.
         /// </summary>
-        public int? Plannedeffort { get; set; }
+        public int? PlannedEffort { get; set; }
 
         /// <summary>
         /// The planned cost for this Task.  Cannot be negative.
         /// </summary>
-        public decimal? Plannedcost { get; set; }
+        public decimal? PlannedCost { get; set; }
 
         /// <summary>
         /// If set, this is the actual date when work began on the Task.
@@ -122,12 +122,12 @@ namespace ProjectManager.SDK.Models
         ///
         /// This is a date-only field stored as a string in ISO 8601 (YYYY-MM-DD) format.
         /// </summary>
-        public string Actualstartdate { get; set; }
+        public string ActualStartDate { get; set; }
 
         /// <summary>
         /// If set, this represents the actual tracked cost for this Task.
         /// </summary>
-        public decimal? Actualcost { get; set; }
+        public decimal? ActualCost { get; set; }
 
         /// <summary>
         /// Color theme definition for this task.

--- a/src/Models/TimeSheetProjectDto.cs
+++ b/src/Models/TimeSheetProjectDto.cs
@@ -48,7 +48,7 @@ namespace ProjectManager.SDK.Models
         /// name can be edited in the Project Settings page within the application
         /// and can be any text you wish.
         /// </summary>
-        public string Shortcode { get; set; }
+        public string ShortCode { get; set; }
 
         /// <summary>
         /// A short identifier that uniquely identifies this Project within your Workspace
@@ -62,28 +62,28 @@ namespace ProjectManager.SDK.Models
         ///
         /// This code is automatically assigned for you and cannot be changed.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The earliest planned or actual start date of tasks on the project.
         ///
         /// This field is calculated automatically and cannot be changed.
         /// </summary>
-        public DateTime? Startdate { get; set; }
+        public DateTime? StartDate { get; set; }
 
         /// <summary>
         /// The latest planned or actual finish date of tasks on the project.
         ///
         /// This field is calculated automatically and cannot be changed.
         /// </summary>
-        public DateTime? Enddate { get; set; }
+        public DateTime? EndDate { get; set; }
 
         /// <summary>
         /// The target planned completion date for this Project, or null if one has
         /// not been selected.  This value can be updated in the Project Settings
         /// page or the Portfolio Project page within the application.
         /// </summary>
-        public DateTime? Targetdate { get; set; }
+        public DateTime? TargetDate { get; set; }
 
         /// <summary>
         /// The proposed budget for this Project.
@@ -95,7 +95,7 @@ namespace ProjectManager.SDK.Models
         /// if an assignee working on this Project does not have an hourly rate configured
         /// in their profile.
         /// </summary>
-        public decimal? Hourlyrate { get; set; }
+        public decimal? HourlyRate { get; set; }
 
         /// <summary>
         /// Contains an optional status update for Projects that can be used to summarize
@@ -103,22 +103,22 @@ namespace ProjectManager.SDK.Models
         ///
         /// You can edit the StatusUpdate field on the Portfolio page of the application.
         /// </summary>
-        public string Statusupdate { get; set; }
+        public string StatusUpdate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when the Project was most recently modified.
         /// </summary>
-        public DateTime? Modifydate { get; set; }
+        public DateTime? ModifyDate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when the Project was created.
         /// </summary>
-        public DateTime? Createdate { get; set; }
+        public DateTime? CreateDate { get; set; }
 
         /// <summary>
         /// True if this Project is a template that will be reused as a framework
         /// for future Projects.
         /// </summary>
-        public bool? Istemplate { get; set; }
+        public bool? IsTemplate { get; set; }
     }
 }

--- a/src/Models/TimesheetCreateRequestDto.cs
+++ b/src/Models/TimesheetCreateRequestDto.cs
@@ -41,17 +41,17 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Task id that time reported to
         /// </summary>
-        public Guid? Taskid { get; set; }
+        public Guid? TaskId { get; set; }
 
         /// <summary>
         /// Admin task id that time reportsed to
         /// </summary>
-        public Guid? Admintypeid { get; set; }
+        public Guid? AdminTypeId { get; set; }
 
         /// <summary>
         /// Resource id that time reported to
         /// </summary>
-        public Guid? Resourceid { get; set; }
+        public Guid? ResourceId { get; set; }
 
         /// <summary>
         /// Notes

--- a/src/Models/TimesheetDto.cs
+++ b/src/Models/TimesheetDto.cs
@@ -54,7 +54,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// Date and time (in UTC) that this timesheet entry was last modified.
         /// </summary>
-        public DateTime? Modifieddate { get; set; }
+        public DateTime? ModifiedDate { get; set; }
 
         /// <summary>
         /// The task associated with this timesheet entry
@@ -74,7 +74,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The administration type associated with this timesheet entry
         /// </summary>
-        public TimesheetAdminTypeDto Admintype { get; set; }
+        public TimesheetAdminTypeDto AdminType { get; set; }
 
         /// <summary>
         /// The list of files associated with this Timesheet, if any.

--- a/src/Models/TimesheetFileDto.cs
+++ b/src/Models/TimesheetFileDto.cs
@@ -20,9 +20,6 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
-    /// <summary>
-    /// A file attached to a timesheet
-    /// </summary>
     public class TimesheetFileDto : ApiModel
     {
 

--- a/src/Models/TimesheetResourceDto.cs
+++ b/src/Models/TimesheetResourceDto.cs
@@ -40,14 +40,14 @@ namespace ProjectManager.SDK.Models
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Firstname { get; set; }
+        public string FirstName { get; set; }
 
         /// <summary>
         /// The last name of the person Resource.
         ///
         /// Applies to personnel Resources only.
         /// </summary>
-        public string Lastname { get; set; }
+        public string LastName { get; set; }
 
         /// <summary>
         /// The email address of this Resource.

--- a/src/Models/TimesheetResponseDto.cs
+++ b/src/Models/TimesheetResponseDto.cs
@@ -34,22 +34,22 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// associated task id
         /// </summary>
-        public Guid? Taskid { get; set; }
+        public Guid? TaskId { get; set; }
 
         /// <summary>
         /// associated project id
         /// </summary>
-        public Guid? Projectid { get; set; }
+        public Guid? ProjectId { get; set; }
 
         /// <summary>
         /// resource id time entry entered
         /// </summary>
-        public Guid? Resourceid { get; set; }
+        public Guid? ResourceId { get; set; }
 
         /// <summary>
         /// admin task id
         /// </summary>
-        public Guid? Timesheetadmintypeid { get; set; }
+        public Guid? TimesheetAdminTypeId { get; set; }
 
         /// <summary>
         /// Date of time entry

--- a/src/Models/TimesheetTaskDto.cs
+++ b/src/Models/TimesheetTaskDto.cs
@@ -36,13 +36,13 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique identifier of the Project to which this Task belongs.
         /// </summary>
-        public Guid? Projectid { get; set; }
+        public Guid? ProjectId { get; set; }
 
         /// <summary>
         /// A short ID that can be used to refer to this Task.  This short ID is
         /// guaranteed to be unique within your Workspace.
         /// </summary>
-        public string Shortid { get; set; }
+        public string ShortId { get; set; }
 
         /// <summary>
         /// The common name of this Task.
@@ -67,7 +67,7 @@ namespace ProjectManager.SDK.Models
         /// savings time).  This project is considered overdue on 12:01 AM July 6th 2023 in
         /// US Pacific time.
         /// </summary>
-        public DateTime? Plannedstartdate { get; set; }
+        public DateTime? PlannedStartDate { get; set; }
 
         /// <summary>
         /// The date when work on this Task is expected to complete.
@@ -82,7 +82,7 @@ namespace ProjectManager.SDK.Models
         /// savings time).  This project is considered overdue on 12:01 AM July 6th 2023 in
         /// US Pacific time.
         /// </summary>
-        public DateTime? Plannedfinishdate { get; set; }
+        public DateTime? PlannedFinishDate { get; set; }
 
         /// <summary>
         /// If set, this is the actual date when work began on the Task.
@@ -97,7 +97,7 @@ namespace ProjectManager.SDK.Models
         /// savings time).  This project is considered overdue on 12:01 AM July 6th 2023 in
         /// US Pacific time.
         /// </summary>
-        public DateTime? Actualstartdate { get; set; }
+        public DateTime? ActualStartDate { get; set; }
 
         /// <summary>
         /// If set, this is the actual date when work was completed on this Task.
@@ -112,17 +112,17 @@ namespace ProjectManager.SDK.Models
         /// savings time).  This project is considered overdue on 12:01 AM July 6th 2023 in
         /// US Pacific time.
         /// </summary>
-        public DateTime? Actualfinishdate { get; set; }
+        public DateTime? ActualFinishDate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when this Task was most recently modified.
         /// </summary>
-        public DateTime? Modifydate { get; set; }
+        public DateTime? ModifyDate { get; set; }
 
         /// <summary>
         /// The timestamp in UTC when this Task was created.
         /// </summary>
-        public DateTime? Createdate { get; set; }
+        public DateTime? CreateDate { get; set; }
 
         /// <summary>
         /// The numerical percentage, from 0-100, representing the percentage completion
@@ -132,7 +132,7 @@ namespace ProjectManager.SDK.Models
         /// This value can be edited manually in the Gantt chart view of the application,
         /// or can be selected on the Task Detail page within the Kanban board.
         /// </summary>
-        public int? Percentcomplete { get; set; }
+        public int? PercentComplete { get; set; }
 
         /// <summary>
         /// True if this Task is the parent of multiple Tasks underneath it.  A parent Task
@@ -142,12 +142,12 @@ namespace ProjectManager.SDK.Models
         /// You can create a summary Task in the Gantt chart view of the application by
         /// adding child tasks underneath a parent Task.
         /// </summary>
-        public bool? Issummary { get; set; }
+        public bool? IsSummary { get; set; }
 
         /// <summary>
         /// Return the priority of a task
         /// </summary>
-        public int? Priorityid { get; set; }
+        public int? PriorityId { get; set; }
 
         /// <summary>
         /// The WBS (Work Breakdown Structure) number for this task within the Gantt chart hierarchy.  See [What
@@ -168,11 +168,11 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The actual cost of this Task to date, if known.
         /// </summary>
-        public decimal? Actualcost { get; set; }
+        public decimal? ActualCost { get; set; }
 
         /// <summary>
         /// The planned cost for this Task.  Cannot be negative.
         /// </summary>
-        public decimal? Plannedcost { get; set; }
+        public decimal? PlannedCost { get; set; }
     }
 }

--- a/src/Models/UpdateRequestDto.cs
+++ b/src/Models/UpdateRequestDto.cs
@@ -40,11 +40,11 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// To assign this File to a Task, specify the TaskId here.
         /// </summary>
-        public Guid? Taskid { get; set; }
+        public Guid? TaskId { get; set; }
 
         /// <summary>
         /// To move this File to a new Folder, specify the Folder&#39;s unique identifier here.
         /// </summary>
-        public Guid? Folderid { get; set; }
+        public Guid? FolderId { get; set; }
     }
 }

--- a/src/Models/WorkSpaceDto.cs
+++ b/src/Models/WorkSpaceDto.cs
@@ -41,23 +41,23 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique DNS domain of this Workspace.
         /// </summary>
-        public string Customproductdomain { get; set; }
+        public string CustomProductDomain { get; set; }
 
         /// <summary>
         /// TODO - What is this value?
         /// </summary>
-        public Guid? Customerid { get; set; }
+        public Guid? CustomerId { get; set; }
 
         /// <summary>
         /// This value is set to true if the user who retrieves this Workspace object via an API call is
         /// the owner of this Workspace.
         /// </summary>
-        public bool? Isowner { get; set; }
+        public bool? IsOwner { get; set; }
 
         /// <summary>
         /// The organization code used for authentication systems for this Workspace.
         /// </summary>
-        public string Organizationid { get; set; }
+        public string OrganizationId { get; set; }
 
         /// <summary>
         /// The RGB color in the format `#RRGGBB` for this Workspace.
@@ -67,26 +67,26 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The role of the current user within this Workspace.
         /// </summary>
-        public string Rolename { get; set; }
+        public string RoleName { get; set; }
 
         /// <summary>
         /// The timestamp when the Workspace was created.
         /// </summary>
-        public DateTime? Registerdate { get; set; }
+        public DateTime? RegisterDate { get; set; }
 
         /// <summary>
         /// True if the user has accepted an invitation to this Workspace.
         /// </summary>
-        public bool? Isinviteaccepted { get; set; }
+        public bool? IsInviteAccepted { get; set; }
 
         /// <summary>
         /// The unique identifier of the BusinessUser that is the owner of this Workspace.
         /// </summary>
-        public Guid? Businessuserid { get; set; }
+        public Guid? BusinessUserId { get; set; }
 
         /// <summary>
         /// True if this Workspace has an active subscription; false if this is a free trial.
         /// </summary>
-        public bool? Ispaid { get; set; }
+        public bool? IsPaid { get; set; }
     }
 }

--- a/src/Models/WorkSpaceJoinDto.cs
+++ b/src/Models/WorkSpaceJoinDto.cs
@@ -31,6 +31,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The unique identifier of the BusinessUser to invite to this Workspace.
         /// </summary>
-        public Guid? Businessuserid { get; set; }
+        public Guid? BusinessUserId { get; set; }
     }
 }

--- a/src/Models/WorkSpaceLinksDto.cs
+++ b/src/Models/WorkSpaceLinksDto.cs
@@ -34,6 +34,6 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// This is the link to the api for this business.  Some endpoints may need this value.
         /// </summary>
-        public string Workspaceapi { get; set; }
+        public string WorkSpaceApi { get; set; }
     }
 }

--- a/src/Models/WorkSpaceUserInfoDto.cs
+++ b/src/Models/WorkSpaceUserInfoDto.cs
@@ -36,7 +36,7 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The email address of the currently logged in user.
         /// </summary>
-        public string Emailaddress { get; set; }
+        public string EmailAddress { get; set; }
 
         /// <summary>
         /// The unique identity of the currently logged in user.
@@ -46,27 +46,27 @@ namespace ProjectManager.SDK.Models
         /// <summary>
         /// The full name of the currently logged in user.
         /// </summary>
-        public string Fullname { get; set; }
+        public string FullName { get; set; }
 
         /// <summary>
         /// The name of the Workspace that the current user has logged onto.  For most companies, the workspace
         /// name will be the name of the business.
         /// </summary>
-        public string Workspacename { get; set; }
+        public string WorkSpaceName { get; set; }
 
         /// <summary>
         /// The user&#39;s role within the current Workspace.
         /// </summary>
-        public string Rolename { get; set; }
+        public string RoleName { get; set; }
 
         /// <summary>
         /// True if this user is considered a global administrator of the current Workspace.
         /// </summary>
-        public bool? Isglobaladmin { get; set; }
+        public bool? IsGlobalAdmin { get; set; }
 
         /// <summary>
         /// True if this user is considered an account administrator of the current Workspace.
         /// </summary>
-        public bool? Isaccountadministrator { get; set; }
+        public bool? IsAccountAdministrator { get; set; }
     }
 }

--- a/src/ProjectManagerClient.cs
+++ b/src/ProjectManagerClient.cs
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    102.0.2886
+ * @version    102.0.2949
  * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
  */
 
@@ -39,7 +39,7 @@ namespace ProjectManager.SDK
         /// <summary>
         /// The version of the SDK
         /// </summary>
-        public const string SdkVersion = "102.0.2886";
+        public const string SdkVersion = "102.0.2949";
         
         private readonly string _apiUrl;
         private readonly HttpClient _client;


### PR DESCRIPTION
The previous build, version 2887, caused capitalization differences for some APIs and methods and parameters.  It incorrectly converted names that were already in PascalCase form into first-character-uppercase-all-others-lowercase.

Let's fix.