### PR TITLE
Release 104

### DIFF
--- a/ProjectManagerClient.nuspec
+++ b/ProjectManagerClient.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>ProjectManager.SDK</id>
-		<version>103.0.3003</version>
+		<version>104.0.3086</version>
 		<title>ProjectManager.SDK</title>
 		<authors>ProjectManager.com</authors>
 		<owners>ProjectManager.com, Inc.</owners>
@@ -14,16 +14,19 @@
 		<readme>docs/README.md</readme>
 		<summary>ProjectManager API for DotNet</summary>
 		<releaseNotes>
-# Patch notes for 103.0.3003
-
-These patch notes summarize the changes from version 102.0.2886.
-
-Added 2 new APIs:
-* Changeset.RetrieveChangesetsByProjectID (GET /api/data/projects/{projectId}/changesets)
-* Project.DeleteProject (DELETE /api/data/projects/{projectId})
-
-Deprecated 1 old APIs:
-* TaskMetadata.GetTaskMetadata
+            # Patch notes for 104.0.3086
+            
+            These patch notes summarize the changes from version 103.0.3003.
+            
+            Added 1 new APIs:
+            * Changeset.RetrieveProjectChangesByProjectID (GET /api/data/projects/{projectId}/changes)
+            
+            Renamed 2 old APIs:
+            * Renamed 'Changeset.RetrieveChangeset' to 'Changeset.RetrieveChangesetStatus'
+            * Renamed 'Changeset.RetrieveCompletedChangeset' to 'Changeset.RetrieveCompletedChangesetStatus'
+            
+            Deprecated 1 old APIs:
+            * TaskMetadata.GetTaskMetadata
             
 
         </releaseNotes>

--- a/src/Clients/ChangesetClient.cs
+++ b/src/Clients/ChangesetClient.cs
@@ -47,10 +47,10 @@ namespace ProjectManager.SDK.Clients
         ///
         /// </summary>
         /// <param name="changeSetId">The unique ID number of the Changeset to retrieve</param>
-        public async Task<AstroResult<ChangesetGetResponseDto>> RetrieveChangeset(Guid changeSetId)
+        public async Task<AstroResult<ProjectChangeStatusDto>> RetrieveChangesetStatus(Guid changeSetId)
         {
             var url = $"/api/data/changesets/{changeSetId}";
-            return await _client.Request<ChangesetGetResponseDto>(HttpMethod.Get, url, null, null, null);
+            return await _client.Request<ProjectChangeStatusDto>(HttpMethod.Get, url, null, null, null);
         }
 
         /// <summary>
@@ -64,28 +64,28 @@ namespace ProjectManager.SDK.Clients
         ///
         /// </summary>
         /// <param name="changeSetId">The unique ID number of the Changeset to retrieve</param>
-        public async Task<AstroResult<ChangesetGetResponseDto>> RetrieveCompletedChangeset(Guid changeSetId)
+        public async Task<AstroResult<ProjectChangeStatusDto>> RetrieveCompletedChangesetStatus(Guid changeSetId)
         {
             var url = $"/api/data/changesets/{changeSetId}/poll";
-            return await _client.Request<ChangesetGetResponseDto>(HttpMethod.Get, url, null, null, null);
+            return await _client.Request<ProjectChangeStatusDto>(HttpMethod.Get, url, null, null, null);
         }
 
         /// <summary>
-        /// Retrieve Changesets by Project ID
+        /// Retrieve specific Project Changes by Project ID
         ///
         /// </summary>
         /// <param name="projectId"></param>
         /// <param name="version"></param>
         /// <param name="page"></param>
         /// <param name="take"></param>
-        public async Task<AstroResult<ChangeSetResponseDto[]>> RetrieveChangesetsByProjectID(Guid projectId, int? version = null, int? page = null, int? take = null)
+        public async Task<AstroResult<ProjectChangeDto[]>> RetrieveProjectChangesByProjectID(Guid projectId, int? version = null, int? page = null, int? take = null)
         {
-            var url = $"/api/data/projects/{projectId}/changesets";
+            var url = $"/api/data/projects/{projectId}/changes";
             var options = new Dictionary<string, object>();
             if (version != null) { options["version"] = version; }
             if (page != null) { options["page"] = page; }
             if (take != null) { options["take"] = take; }
-            return await _client.Request<ChangeSetResponseDto[]>(HttpMethod.Get, url, options, null, null);
+            return await _client.Request<ProjectChangeDto[]>(HttpMethod.Get, url, options, null, null);
         }
     }
 }

--- a/src/IProjectManagerClient.cs
+++ b/src/IProjectManagerClient.cs
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    103.0.3003
+ * @version    104.0.3086
  * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
  */
 

--- a/src/Interfaces/IChangesetClient.cs
+++ b/src/Interfaces/IChangesetClient.cs
@@ -36,7 +36,7 @@ namespace ProjectManager.SDK.Interfaces
         ///
         /// </summary>
         /// <param name="changeSetId">The unique ID number of the Changeset to retrieve</param>
-        Task<AstroResult<ChangesetGetResponseDto>> RetrieveChangeset(Guid changeSetId);
+        Task<AstroResult<ProjectChangeStatusDto>> RetrieveChangesetStatus(Guid changeSetId);
 
         /// <summary>
         /// Retrieve a Changeset by its unique ID. This endpoint waits for the Changeset to complete its processing prior to returning a result.
@@ -49,16 +49,16 @@ namespace ProjectManager.SDK.Interfaces
         ///
         /// </summary>
         /// <param name="changeSetId">The unique ID number of the Changeset to retrieve</param>
-        Task<AstroResult<ChangesetGetResponseDto>> RetrieveCompletedChangeset(Guid changeSetId);
+        Task<AstroResult<ProjectChangeStatusDto>> RetrieveCompletedChangesetStatus(Guid changeSetId);
 
         /// <summary>
-        /// Retrieve Changesets by Project ID
+        /// Retrieve specific Project Changes by Project ID
         ///
         /// </summary>
         /// <param name="projectId"></param>
         /// <param name="version"></param>
         /// <param name="page"></param>
         /// <param name="take"></param>
-        Task<AstroResult<ChangeSetResponseDto[]>> RetrieveChangesetsByProjectID(Guid projectId, int? version = null, int? page = null, int? take = null);
+        Task<AstroResult<ProjectChangeDto[]>> RetrieveProjectChangesByProjectID(Guid projectId, int? version = null, int? page = null, int? take = null);
     }
 }

--- a/src/Models/ChangeSetDto.cs
+++ b/src/Models/ChangeSetDto.cs
@@ -1,0 +1,109 @@
+/***
+ * ProjectManager API for C#
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
+ */
+
+
+
+#pragma warning disable CS8618
+
+using System;
+
+namespace ProjectManager.SDK.Models
+{
+
+    /// <summary>
+    /// The project task change set
+    /// </summary>
+    public class ChangeSetDto : ApiModel
+    {
+
+        /// <summary>
+        /// Project Changeset ID
+        /// </summary>
+        public int? ProjectChangeSetId { get; set; }
+
+        /// <summary>
+        /// The unique identifier of this Changeset
+        /// </summary>
+        public Guid? Id { get; set; }
+
+        /// <summary>
+        /// Project ID
+        /// </summary>
+        public Guid? ProjectId { get; set; }
+
+        /// <summary>
+        /// Task version
+        /// </summary>
+        public int? Version { get; set; }
+
+        /// <summary>
+        /// Created by GUID
+        /// </summary>
+        public Guid? CreateBy { get; set; }
+
+        /// <summary>
+        /// Created date
+        /// </summary>
+        public DateTime? CreateDate { get; set; }
+
+        /// <summary>
+        /// Change set action
+        /// </summary>
+        public string Actions { get; set; }
+
+        /// <summary>
+        /// Change set in json string
+        /// </summary>
+        public string ChangeSets { get; set; }
+
+        /// <summary>
+        /// Processed date
+        /// </summary>
+        public DateTime? ProcessDate { get; set; }
+
+        /// <summary>
+        /// If process was successful
+        /// </summary>
+        public bool? Success { get; set; }
+
+        /// <summary>
+        /// Error message
+        /// </summary>
+        public string Exception { get; set; }
+
+        /// <summary>
+        /// UI ID
+        /// </summary>
+        public Guid? ClientId { get; set; }
+
+        /// <summary>
+        /// Changeset JSON data
+        /// </summary>
+        public string JsonData { get; set; }
+
+        /// <summary>
+        /// Is change set from UNDO
+        /// </summary>
+        public bool? IsUndo { get; set; }
+
+        /// <summary>
+        /// The state of the changeset
+        /// </summary>
+        public int? State { get; set; }
+
+        /// <summary>
+        /// Business ID
+        /// </summary>
+        public Guid? BusinessId { get; set; }
+    }
+}

--- a/src/Models/ProjectChangeDto.cs
+++ b/src/Models/ProjectChangeDto.cs
@@ -21,20 +21,20 @@ namespace ProjectManager.SDK.Models
 {
 
     /// <summary>
-    /// The project task change set
+    /// The specific change action made against a project
     /// </summary>
-    public class ChangeSetResponseDto : ApiModel
+    public class ProjectChangeDto : ApiModel
     {
 
         /// <summary>
-        /// Project Changeset ID
-        /// </summary>
-        public int? ProjectChangeSetId { get; set; }
-
-        /// <summary>
-        /// The unique identifier of this Changeset
+        /// Project Change ID
         /// </summary>
         public Guid? Id { get; set; }
+
+        /// <summary>
+        /// Workspace ID
+        /// </summary>
+        public Guid? BusinessId { get; set; }
 
         /// <summary>
         /// Project ID
@@ -42,7 +42,7 @@ namespace ProjectManager.SDK.Models
         public Guid? ProjectId { get; set; }
 
         /// <summary>
-        /// Task version
+        /// Version of this Project Change
         /// </summary>
         public int? Version { get; set; }
 
@@ -57,53 +57,18 @@ namespace ProjectManager.SDK.Models
         public DateTime? CreateDate { get; set; }
 
         /// <summary>
-        /// Change set action
-        /// </summary>
-        public string Actions { get; set; }
-
-        /// <summary>
-        /// Change set in json string
-        /// </summary>
-        public string ChangeSets { get; set; }
-
-        /// <summary>
         /// Processed date
         /// </summary>
         public DateTime? ProcessDate { get; set; }
 
         /// <summary>
-        /// If process was successful
+        /// The status of the Project Change
         /// </summary>
-        public bool? Success { get; set; }
+        public int? Status { get; set; }
 
         /// <summary>
-        /// Error message
+        /// Project Change as JSON data
         /// </summary>
-        public string Exception { get; set; }
-
-        /// <summary>
-        /// UI ID
-        /// </summary>
-        public Guid? ClientId { get; set; }
-
-        /// <summary>
-        /// Changeset JSON data
-        /// </summary>
-        public string JsonData { get; set; }
-
-        /// <summary>
-        /// Is change set from UNDO
-        /// </summary>
-        public bool? IsUndo { get; set; }
-
-        /// <summary>
-        /// The state of the changeset
-        /// </summary>
-        public int? State { get; set; }
-
-        /// <summary>
-        /// Business ID
-        /// </summary>
-        public Guid? BusinessId { get; set; }
+        public object ChangeData { get; set; }
     }
 }

--- a/src/Models/ProjectChangeStatusDto.cs
+++ b/src/Models/ProjectChangeStatusDto.cs
@@ -21,27 +21,27 @@ namespace ProjectManager.SDK.Models
 {
 
     /// <summary>
-    /// A Changeset is an individual edit that has been made to a project.  Since multiple users can
-    /// edit a project at the same time, individual Changesets are applied in a sequential fashion. If
-    /// a Changeset causes a conflict or cannot be applied, it will be rejected.  You can examine a
-    /// Changeset to determine its conflict resolution status.
+    /// A ProjectChange is an individual edit that has been made to a project.  Since multiple users
+    /// can edit a project at the same time, individual ProjectChanges are applied in a sequential
+    /// fashion. If a ProjectChange causes a conflict or cannot be applied, it will be rejected.
+    /// You can examine a ProjectChange to determine its conflict resolution status.
     /// </summary>
-    public class ChangesetGetResponseDto : ApiModel
+    public class ProjectChangeStatusDto : ApiModel
     {
 
         /// <summary>
-        /// The unique identifier of this Changeset.
+        /// The unique identifier of this ProjectChange.
         /// </summary>
         public Guid? Id { get; set; }
 
         /// <summary>
-        /// True if this Changeset was successfully applied.  If the Changeset has not been applied,
-        /// this value is null.
+        /// True if this ProjectChange was successfully applied.  If the ProjectChange has not been
+        /// applied, this value is null.
         /// </summary>
         public bool? Success { get; set; }
 
         /// <summary>
-        /// A status flag that indicates the progress of the Changeset through resolution.
+        /// A status flag that indicates the progress of the ProjectChange through resolution.
         ///
         /// For a list of values, see `StateValues`.
         /// </summary>

--- a/src/ProjectManagerClient.cs
+++ b/src/ProjectManagerClient.cs
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    103.0.3003
+ * @version    104.0.3086
  * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
  */
 
@@ -39,7 +39,7 @@ namespace ProjectManager.SDK
         /// <summary>
         /// The version of the SDK
         /// </summary>
-        public const string SdkVersion = "103.0.3003";
+        public const string SdkVersion = "104.0.3086";
         
         private readonly string _apiUrl;
         private readonly HttpClient _client;
@@ -246,12 +246,6 @@ namespace ProjectManager.SDK
         /// <param name="clientHandler">Handler for the HTTP client, when null the default handler will be used</param>
         private ProjectManagerClient(Uri baseEndpoint, HttpClientHandler clientHandler)
         {
-            // Throw error if not HTTPS
-            if (baseEndpoint.Scheme != "https")
-            {
-                throw new InvalidOperationException("Invalid environment url. Please ensure the environment url starts with 'https://'");
-            }
-
             // Add support for HTTP compression
             var handler = clientHandler ?? new HttpClientHandler();
             handler.AutomaticDecompression = DecompressionMethods.GZip;


### PR DESCRIPTION
# Patch notes for 104.0.3086

These patch notes summarize the changes from version 103.0.3003.

Added 1 new APIs:
* Changeset.RetrieveProjectChangesByProjectID (GET /api/data/projects/{projectId}/changes)

Renamed 2 old APIs:
* Renamed 'Changeset.RetrieveChangeset' to 'Changeset.RetrieveChangesetStatus'
* Renamed 'Changeset.RetrieveCompletedChangeset' to 'Changeset.RetrieveCompletedChangesetStatus'

Deprecated 1 old APIs:
* TaskMetadata.GetTaskMetadata