### PR TITLE
Release 119 - Enable custom HTTP client

### DIFF
--- a/ProjectManagerClient.nuspec
+++ b/ProjectManagerClient.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>ProjectManager.SDK</id>
-		<version>117.0.4438</version>
+		<version>119.0.4625</version>
 		<title>ProjectManager.SDK</title>
 		<authors>ProjectManager.com</authors>
 		<owners>ProjectManager.com, Inc.</owners>
@@ -14,15 +14,23 @@
 		<readme>docs/README.md</readme>
 		<summary>ProjectManager API for DotNet</summary>
 		<releaseNotes>
-            # Patch notes for 117.0.4438
+            # Patch notes for 119.0.4625
             
-            These patch notes summarize the changes from version 116.0.4391.
+            These patch notes summarize the changes from version 117.0.4438.
+            
+            Added 5 new APIs:
+            * ProjectVersion.RetrieveProjectVersions (GET /api/data/projects/{projectId}/versions)
+            * ProjectVersion.DownloadMSProjectXml (GET /api/data/projects/{projectChangeId}/version/download)
+            * ProjectVersion.RestoreProjectVersion (POST /api/data/projects/{projectId}/version/{version}/restore)
+            * ProjectVersion.CopyProjectVersion (POST /api/data/projects/{projectId}/version/{version}/copy)
+            * Risk.CreateRiskExport (POST /api/data/projects/{projectId}/risks/export)
+            
+            Renamed 1 old APIs:
+            * Renamed 'TaskMetadata.GetTasksByProjectIDAndForeignKeyID' to 'TaskMetadata.TaskMetadataSearch'
             
             Changes to data models:
-            * ResourceCreateDto: Added new field `colorName`
-            * ResourceDto: Added new field `colorName`
-            * ResourceDto: Added new field `color`
-            * ResourceUpdateDto: Added new field `colorName`
+            * TaskDto: Added new field `isLocked`
+            * TaskDto: Added new field `isMilestone`
             
 
         </releaseNotes>

--- a/src/Clients/NotificationClient.cs
+++ b/src/Clients/NotificationClient.cs
@@ -103,7 +103,7 @@ namespace ProjectManager.SDK.Clients
         /// workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
         /// than 1,000 pending notifications some old notifications will be deleted automatically.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id">The unique identifier of the notification to mark read</param>
         public async Task<AstroResult<NotificationTimestampDto>> MarkNotificationRead(Guid id)
         {
             var url = $"/api/data/notifications/{id}/markread";
@@ -130,7 +130,7 @@ namespace ProjectManager.SDK.Clients
         /// workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
         /// than 1,000 pending notifications some old notifications will be deleted automatically.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id">The unique identifier of the notification to mark read</param>
         public async Task<AstroResult<string>> DeleteNotification(Guid id)
         {
             var url = $"/api/data/notifications/delete/{id}";
@@ -144,7 +144,7 @@ namespace ProjectManager.SDK.Clients
         /// workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
         /// than 1,000 pending notifications some old notifications will be deleted automatically.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id">The unique identifier of the notification to mark read</param>
         public async Task<AstroResult<string>> MarkNotificationUnread(Guid id)
         {
             var url = $"/api/data/notifications/{id}/markunread";

--- a/src/Clients/ProjectVersionClient.cs
+++ b/src/Clients/ProjectVersionClient.cs
@@ -1,0 +1,89 @@
+/***
+ * ProjectManager API for C#
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
+ */
+
+
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using ProjectManager.SDK.Interfaces;
+using ProjectManager.SDK.Models;
+
+
+namespace ProjectManager.SDK.Clients
+{
+    /// <summary>
+    /// API methods related to ProjectVersion
+    /// </summary>
+    public class ProjectVersionClient : IProjectVersionClient
+    {
+        private readonly ProjectManagerClient _client;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public ProjectVersionClient(ProjectManagerClient client)
+        {
+            _client = client;
+        }
+
+        /// <summary>
+        /// Returns projects versions including version, user who made changes
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project</param>
+        public async Task<AstroResult<ProjectVersionDto[]>> RetrieveProjectVersions(Guid projectId)
+        {
+            var url = $"/api/data/projects/{projectId}/versions";
+            return await _client.Request<ProjectVersionDto[]>(HttpMethod.Get, url, null);
+        }
+
+        /// <summary>
+        /// Exports and returns project version as an MS Project XML attachment
+        /// </summary>
+        /// <param name="projectChangeId">Project change Guid</param>
+        public async Task<AstroResult<byte[]>> DownloadMSProjectXml(Guid projectChangeId)
+        {
+            var url = $"/api/data/projects/{projectChangeId}/version/download";
+            return await _client.Request<byte[]>(HttpMethod.Get, url, null);
+        }
+
+        /// <summary>
+        /// Restores a Project to the state it was in at a specific Version in time.
+        ///
+        /// If successful, all changes made to the Project since this Version will be undone and the Project will
+        /// return to its former state.
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project to restore</param>
+        /// <param name="version">The version number to restore to</param>
+        public async Task<AstroResult<string>> RestoreProjectVersion(Guid projectId, int version)
+        {
+            var url = $"/api/data/projects/{projectId}/version/{version}/restore";
+            return await _client.Request<string>(HttpMethod.Post, url, null);
+        }
+
+        /// <summary>
+        /// Create a Copy of a Project as of a specific Version, optionally moving it to a new Timezone.
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project to copy</param>
+        /// <param name="version">The version number of the Project to copy</param>
+        /// <param name="timezoneOffset">If specified, sets the default timezone of the newly copied Project to this specified timezone</param>
+        public async Task<AstroResult<string>> CopyProjectVersion(Guid projectId, int version, int? timezoneOffset = null)
+        {
+            var url = $"/api/data/projects/{projectId}/version/{version}/copy";
+            var options = new Dictionary<string, object>();
+            if (timezoneOffset != null) { options["timezoneOffset"] = timezoneOffset; }
+            return await _client.Request<string>(HttpMethod.Post, url, options);
+        }
+    }
+}

--- a/src/Clients/RiskClient.cs
+++ b/src/Clients/RiskClient.cs
@@ -1,0 +1,54 @@
+/***
+ * ProjectManager API for C#
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
+ */
+
+
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using ProjectManager.SDK.Interfaces;
+using ProjectManager.SDK.Models;
+
+
+namespace ProjectManager.SDK.Clients
+{
+    /// <summary>
+    /// API methods related to Risk
+    /// </summary>
+    public class RiskClient : IRiskClient
+    {
+        private readonly ProjectManagerClient _client;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public RiskClient(ProjectManagerClient client)
+        {
+            _client = client;
+        }
+
+        /// <summary>
+        /// Initiates a new Export action for Risks.
+        ///
+        /// Returns the identifier of this Risk Export.
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project for which to export Risks</param>
+        /// <param name="body">The settings to use for this export action</param>
+        public async Task<AstroResult<ExportDto>> CreateRiskExport(Guid projectId, RiskExportSettingsDto body)
+        {
+            var url = $"/api/data/projects/{projectId}/risks/export";
+            return await _client.RequestWithBody<ExportDto>(HttpMethod.Post, url, null, body);
+        }
+    }
+}

--- a/src/Clients/TaskMetadataClient.cs
+++ b/src/Clients/TaskMetadataClient.cs
@@ -54,7 +54,13 @@ namespace ProjectManager.SDK.Clients
             return await _client.RequestWithBody<string>(HttpMethod.Put, url, options, body);
         }
 
-        public async Task<AstroResult<TaskMetadataSearchDto[]>> GetTasksByProjectIDAndForeignKeyID(Guid projectId, string foreignKey = null, bool? isSystem = null)
+        /// <summary>
+        /// Get tasks by project ID and foreign key ID
+        /// </summary>
+        /// <param name="foreignKey">Foreign Key ID</param>
+        /// <param name="projectId">Project ID</param>
+        /// <param name="isSystem">If metadata is for system or customer, isSystem = true is only of ProjectManager</param>
+        public async Task<AstroResult<TaskMetadataSearchDto[]>> TaskMetadataSearch(Guid projectId, string foreignKey = null, bool? isSystem = null)
         {
             var url = $"/api/data/projects/{projectId}/tasks/metadata";
             var options = new Dictionary<string, object>();

--- a/src/IProjectManagerClient.cs
+++ b/src/IProjectManagerClient.cs
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    117.0.4438
+ * @version    119.0.4625
  * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
  */
 
@@ -120,6 +120,10 @@ namespace ProjectManager.SDK
         /// </summary>
         IProjectTemplateClient ProjectTemplate { get; }
         /// <summary>
+        /// API methods related to ProjectVersion
+        /// </summary>
+        IProjectVersionClient ProjectVersion { get; }
+        /// <summary>
         /// API methods related to Resource
         /// </summary>
         IResourceClient Resource { get; }
@@ -131,6 +135,10 @@ namespace ProjectManager.SDK
         /// API methods related to ResourceTeam
         /// </summary>
         IResourceTeamClient ResourceTeam { get; }
+        /// <summary>
+        /// API methods related to Risk
+        /// </summary>
+        IRiskClient Risk { get; }
         /// <summary>
         /// API methods related to Tag
         /// </summary>

--- a/src/Interfaces/INotificationClient.cs
+++ b/src/Interfaces/INotificationClient.cs
@@ -74,7 +74,7 @@ namespace ProjectManager.SDK.Interfaces
         /// workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
         /// than 1,000 pending notifications some old notifications will be deleted automatically.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id">The unique identifier of the notification to mark read</param>
         Task<AstroResult<NotificationTimestampDto>> MarkNotificationRead(Guid id);
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace ProjectManager.SDK.Interfaces
         /// workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
         /// than 1,000 pending notifications some old notifications will be deleted automatically.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id">The unique identifier of the notification to mark read</param>
         Task<AstroResult<string>> DeleteNotification(Guid id);
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace ProjectManager.SDK.Interfaces
         /// workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
         /// than 1,000 pending notifications some old notifications will be deleted automatically.
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id">The unique identifier of the notification to mark read</param>
         Task<AstroResult<string>> MarkNotificationUnread(Guid id);
     }
 }

--- a/src/Interfaces/IProjectVersionClient.cs
+++ b/src/Interfaces/IProjectVersionClient.cs
@@ -1,0 +1,60 @@
+/***
+ * ProjectManager API for C#
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
+ */
+
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ProjectManager.SDK.Models;
+
+
+namespace ProjectManager.SDK.Interfaces
+{
+    /// <summary>
+    /// API methods related to ProjectVersion
+    /// </summary>
+    public interface IProjectVersionClient
+    {
+
+        /// <summary>
+        /// Returns projects versions including version, user who made changes
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project</param>
+        Task<AstroResult<ProjectVersionDto[]>> RetrieveProjectVersions(Guid projectId);
+
+        /// <summary>
+        /// Exports and returns project version as an MS Project XML attachment
+        /// </summary>
+        /// <param name="projectChangeId">Project change Guid</param>
+        Task<AstroResult<byte[]>> DownloadMSProjectXml(Guid projectChangeId);
+
+        /// <summary>
+        /// Restores a Project to the state it was in at a specific Version in time.
+        ///
+        /// If successful, all changes made to the Project since this Version will be undone and the Project will
+        /// return to its former state.
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project to restore</param>
+        /// <param name="version">The version number to restore to</param>
+        Task<AstroResult<string>> RestoreProjectVersion(Guid projectId, int version);
+
+        /// <summary>
+        /// Create a Copy of a Project as of a specific Version, optionally moving it to a new Timezone.
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project to copy</param>
+        /// <param name="version">The version number of the Project to copy</param>
+        /// <param name="timezoneOffset">If specified, sets the default timezone of the newly copied Project to this specified timezone</param>
+        Task<AstroResult<string>> CopyProjectVersion(Guid projectId, int version, int? timezoneOffset = null);
+    }
+}

--- a/src/Interfaces/IRiskClient.cs
+++ b/src/Interfaces/IRiskClient.cs
@@ -1,0 +1,39 @@
+/***
+ * ProjectManager API for C#
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
+ */
+
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ProjectManager.SDK.Models;
+
+
+namespace ProjectManager.SDK.Interfaces
+{
+    /// <summary>
+    /// API methods related to Risk
+    /// </summary>
+    public interface IRiskClient
+    {
+
+        /// <summary>
+        /// Initiates a new Export action for Risks.
+        ///
+        /// Returns the identifier of this Risk Export.
+        /// </summary>
+        /// <param name="projectId">The unique identifier of the Project for which to export Risks</param>
+        /// <param name="body">The settings to use for this export action</param>
+        Task<AstroResult<ExportDto>> CreateRiskExport(Guid projectId, RiskExportSettingsDto body);
+    }
+}

--- a/src/Interfaces/ITaskMetadataClient.cs
+++ b/src/Interfaces/ITaskMetadataClient.cs
@@ -36,6 +36,12 @@ namespace ProjectManager.SDK.Interfaces
         /// <param name="body">The metadata</param>
         Task<AstroResult<string>> AddMetadata(Guid taskId, TaskMetadataUpdateDto body, bool? isSystem = null, bool? isOverride = null);
 
-        Task<AstroResult<TaskMetadataSearchDto[]>> GetTasksByProjectIDAndForeignKeyID(Guid projectId, string foreignKey = null, bool? isSystem = null);
+        /// <summary>
+        /// Get tasks by project ID and foreign key ID
+        /// </summary>
+        /// <param name="foreignKey">Foreign Key ID</param>
+        /// <param name="projectId">Project ID</param>
+        /// <param name="isSystem">If metadata is for system or customer, isSystem = true is only of ProjectManager</param>
+        Task<AstroResult<TaskMetadataSearchDto[]>> TaskMetadataSearch(Guid projectId, string foreignKey = null, bool? isSystem = null);
     }
 }

--- a/src/Models/DiscussionCommentFileDto.cs
+++ b/src/Models/DiscussionCommentFileDto.cs
@@ -20,6 +20,10 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
+    /// <summary>
+    /// The DiscussionCommentFile represents a file that has been attached to a discussion
+    /// and is available for download.
+    /// </summary>
     public class DiscussionCommentFileDto : ApiModel
     {
 
@@ -34,7 +38,7 @@ namespace ProjectManager.SDK.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// The url of the file which can be used for downloading
+        /// The url of the DownloadFile API to retrieve this file
         /// </summary>
         public string Url { get; set; }
     }

--- a/src/Models/NotificationDataDto.cs
+++ b/src/Models/NotificationDataDto.cs
@@ -51,6 +51,9 @@ namespace ProjectManager.SDK.Models
         /// </summary>
         public string ProjectName { get; set; }
 
+        /// <summary>
+        /// Name of the task this notification is related to
+        /// </summary>
         public string TaskName { get; set; }
 
         /// <summary>

--- a/src/Models/ProjectFileDto.cs
+++ b/src/Models/ProjectFileDto.cs
@@ -20,6 +20,10 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
+    /// <summary>
+    /// The ProjectFile represents an attached file that is connected to a Project
+    /// and can be retrieved for download.
+    /// </summary>
     public class ProjectFileDto : ApiModel
     {
 

--- a/src/Models/ProjectFileTaskDto.cs
+++ b/src/Models/ProjectFileTaskDto.cs
@@ -20,6 +20,9 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
+    /// <summary>
+    /// Represents information about a Task that is relevant to a ProjectFile
+    /// </summary>
     public class ProjectFileTaskDto : ApiModel
     {
 

--- a/src/Models/ProjectVersionChangeDataDto.cs
+++ b/src/Models/ProjectVersionChangeDataDto.cs
@@ -20,17 +20,37 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
+    /// <summary>
+    /// A ProjectVersionChangeData is information about a change made to a Project that took
+    /// it from one Version to another.  The information in this object can help track the
+    /// details of changes made by the user.
+    /// </summary>
     public class ProjectVersionChangeDataDto : ApiModel
     {
 
+        /// <summary>
+        /// The type of change made
+        /// </summary>
         public string Type { get; set; }
 
+        /// <summary>
+        /// The method used to make the change
+        /// </summary>
         public string Method { get; set; }
 
+        /// <summary>
+        /// The property that was changed, if any
+        /// </summary>
         public string Property { get; set; }
 
+        /// <summary>
+        /// The new value of the property, or null if the property was cleared
+        /// </summary>
         public string Value { get; set; }
 
+        /// <summary>
+        /// The prior version number to restore to
+        /// </summary>
         public int? RestoreVersion { get; set; }
     }
 }

--- a/src/Models/ProjectVersionDto.cs
+++ b/src/Models/ProjectVersionDto.cs
@@ -20,6 +20,11 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
+    /// <summary>
+    /// A ProjectVersion is a snapshot of a Project at a specific moment in time.  Information on
+    /// the ProjectVersion record keeps track of the unique identity of this version, plus the name
+    /// and details of the user who created this version, and the changes that were made.
+    /// </summary>
     public class ProjectVersionDto : ApiModel
     {
 

--- a/src/Models/ResourcesCreateDto.cs
+++ b/src/Models/ResourcesCreateDto.cs
@@ -21,6 +21,9 @@ namespace ProjectManager.SDK.Models
 {
 
     /// <summary>
+    /// The ResourcesCreate object allows you to create multiple Users with a single API call.
+    /// In ProjectManager.com, a User is a special class of Resource.
+    ///
     /// A Resource represents a person, material, or tool that is used within your Projects.
     /// When you attach a Resources to more than one Task, the software will schedule the usage
     /// of your Resource so that it is not allocated to more than one Task at the same time.
@@ -31,10 +34,14 @@ namespace ProjectManager.SDK.Models
     {
 
         /// <summary>
-        /// When creating a user they will also be added to the projectIds specified. If null or empty the user will be invited but no access will be given to any projects.
+        /// When creating a user they will also be added to the projectIds specified. If null or empty the user will be
+        /// invited but no access will be given to any projects.
         /// </summary>
         public Guid[] ProjectIds { get; set; }
 
+        /// <summary>
+        /// A list of Users to create
+        /// </summary>
         public ResourceCreateDto[] Users { get; set; }
     }
 }

--- a/src/Models/ResourcesDto.cs
+++ b/src/Models/ResourcesDto.cs
@@ -21,6 +21,8 @@ namespace ProjectManager.SDK.Models
 {
 
     /// <summary>
+    /// The Resources object represents the results of a bulk Resource creation API call.
+    ///
     /// A Resource represents a person, material, or tool that is used within your Projects.
     /// When you attach a Resources to more than one Task, the software will schedule the usage
     /// of your Resource so that it is not allocated to more than one Task at the same time.
@@ -30,8 +32,14 @@ namespace ProjectManager.SDK.Models
     public class ResourcesDto : ApiModel
     {
 
+        /// <summary>
+        /// The list of the Resources created by this API call.
+        /// </summary>
         public ResourceDto[] Resources { get; set; }
 
+        /// <summary>
+        /// The list of errors that occurred for Resources that could not be created.
+        /// </summary>
         public UserError[] Errors { get; set; }
     }
 }

--- a/src/Models/TaskDto.cs
+++ b/src/Models/TaskDto.cs
@@ -183,6 +183,22 @@ namespace ProjectManager.SDK.Models
         public bool? IsSummary { get; set; }
 
         /// <summary>
+        /// Unlocked tasks can be adjusted by changes to their dependencies, resource leveling, or other factors.
+        ///
+        /// All tasks are unlocked by default.
+        ///
+        /// If a task is set to `IsLocked` = `true`, the dates and assigned resources are locked for this task and will not
+        /// be automatically changed by any process.
+        /// </summary>
+        public bool? IsLocked { get; set; }
+
+        /// <summary>
+        /// True if this task is a milestone.  Milestones represent a specific point in time for the project.  When a
+        /// milestone is locked, it represents a fixed time within the project that can be used to relate to other tasks.
+        /// </summary>
+        public bool? IsMilestone { get; set; }
+
+        /// <summary>
         /// Return the priority of a task
         /// </summary>
         public int? PriorityId { get; set; }

--- a/src/Models/TimesheetFileDto.cs
+++ b/src/Models/TimesheetFileDto.cs
@@ -20,6 +20,9 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
+    /// <summary>
+    /// Represents information about a file attached to a Timesheet.
+    /// </summary>
     public class TimesheetFileDto : ApiModel
     {
 

--- a/src/Models/UserError.cs
+++ b/src/Models/UserError.cs
@@ -20,13 +20,26 @@ using System;
 namespace ProjectManager.SDK.Models
 {
 
+    /// <summary>
+    /// Represents an individual error for a specific Resource that could not be created in the context
+    /// of a bulk Resource creation API call.
+    /// </summary>
     public class UserError : ApiModel
     {
 
+        /// <summary>
+        /// The email of the Resource that could not be created
+        /// </summary>
         public string Email { get; set; }
 
+        /// <summary>
+        /// A description of the reason this Resource could not be created
+        /// </summary>
         public string Reason { get; set; }
 
+        /// <summary>
+        /// A status code explaining the category of reason this Resource could not be created
+        /// </summary>
         public string StatusCode { get; set; }
     }
 }

--- a/src/Models/WorkSpaceDto.cs
+++ b/src/Models/WorkSpaceDto.cs
@@ -44,11 +44,6 @@ namespace ProjectManager.SDK.Models
         public string CustomProductDomain { get; set; }
 
         /// <summary>
-        /// TODO - What is this value?
-        /// </summary>
-        public Guid? CustomerId { get; set; }
-
-        /// <summary>
         /// This value is set to true if the user who retrieves this Workspace object via an API call is
         /// the owner of this Workspace.
         /// </summary>

--- a/src/ProjectManagerClient.cs
+++ b/src/ProjectManagerClient.cs
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    117.0.4438
+ * @version    119.0.4625
  * @link       https://github.com/projectmgr/projectmanager-sdk-csharp
  */
 
@@ -39,7 +39,7 @@ namespace ProjectManager.SDK
         /// <summary>
         /// The version of the SDK
         /// </summary>
-        public const string SdkVersion = "117.0.4438";
+        public const string SdkVersion = "119.0.4625";
         
         private readonly string _apiUrl;
         private readonly HttpClient _client;
@@ -170,6 +170,11 @@ namespace ProjectManager.SDK
         public IProjectTemplateClient ProjectTemplate { get; }
 
         /// <summary>
+        /// API methods related to ProjectVersion
+        /// </summary>
+        public IProjectVersionClient ProjectVersion { get; }
+
+        /// <summary>
         /// API methods related to Resource
         /// </summary>
         public IResourceClient Resource { get; }
@@ -183,6 +188,11 @@ namespace ProjectManager.SDK
         /// API methods related to ResourceTeam
         /// </summary>
         public IResourceTeamClient ResourceTeam { get; }
+
+        /// <summary>
+        /// API methods related to Risk
+        /// </summary>
+        public IRiskClient Risk { get; }
 
         /// <summary>
         /// API methods related to Tag
@@ -294,9 +304,11 @@ namespace ProjectManager.SDK
             ProjectPriority = new ProjectPriorityClient(this);
             ProjectStatus = new ProjectStatusClient(this);
             ProjectTemplate = new ProjectTemplateClient(this);
+            ProjectVersion = new ProjectVersionClient(this);
             Resource = new ResourceClient(this);
             ResourceSkill = new ResourceSkillClient(this);
             ResourceTeam = new ResourceTeamClient(this);
+            Risk = new RiskClient(this);
             Tag = new TagClient(this);
             Task = new TaskClient(this);
             TaskAssignee = new TaskAssigneeClient(this);
@@ -355,7 +367,7 @@ namespace ProjectManager.SDK
         /// </summary>
         /// <param name="env">The named environment to use; should be "production"</param>
         /// <param name="client">The HttpClient object to use</param>
-        /// <returns>The ProjectManager API client</returns>
+        /// <returns>The API client to use</returns>
         public static ProjectManagerClient WithCustomHttpClient(string env, HttpClient client)
         {
             switch (env)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
@@ -365,8 +377,8 @@ namespace ProjectManager.SDK
             }
     
             throw new InvalidOperationException($"Unknown environment: {env}");
-        }
-        
+        }        
+
         /// <summary>
         /// Configure this SDK client to set an application name which will be sent with each API call for debugging
         /// purposes.

--- a/src/ProjectManagerClient.cs
+++ b/src/ProjectManagerClient.cs
@@ -361,9 +361,10 @@ namespace ProjectManager.SDK
         }
         
         /// <summary>
-        /// Construct a client that uses a non-standard environment; this can be necessary when using proxy servers or
-        /// an API gateway.  Please be careful when using this mode.
-        /// You should prefer to use `WithEnvironment()` instead wherever possible.
+        /// Construct a client that uses a custom HTTP Client object.  You can use this method to implement your own
+        /// patterns for HttpClient tracking, usage, or to implement a mocked HTTP client during testing.
+        /// Note that for performance reasons your HttpClient should support connection pooling (to avoid unnecessary
+        /// delays in SSL validation) and you should also support GZip encoding.
         /// </summary>
         /// <param name="env">The named environment to use; should be "production"</param>
         /// <param name="client">The HttpClient object to use</param>


### PR DESCRIPTION
These patch notes summarize the changes from version 117.0.4438.

Added 5 new APIs:
* ProjectVersion.RetrieveProjectVersions (GET /api/data/projects/{projectId}/versions)
* ProjectVersion.DownloadMSProjectXml (GET /api/data/projects/{projectChangeId}/version/download)
* ProjectVersion.RestoreProjectVersion (POST /api/data/projects/{projectId}/version/{version}/restore)
* ProjectVersion.CopyProjectVersion (POST /api/data/projects/{projectId}/version/{version}/copy)
* Risk.CreateRiskExport (POST /api/data/projects/{projectId}/risks/export)

Renamed 1 old APIs:
* Renamed 'TaskMetadata.GetTasksByProjectIDAndForeignKeyID' to 'TaskMetadata.TaskMetadataSearch'

Changes to data models:
* TaskDto: Added new field `isLocked`
* TaskDto: Added new field `isMilestone`

Enabled construction of a client that uses your own preferred HttpClient object.