### PR TITLE
Update workflows to be version neutral

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup .NET Core @ Latest
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "9.x"
 
       - name: Build solution and generate NuGet package
         run: dotnet build -c Release
@@ -30,7 +28,6 @@ jobs:
         uses: nuget/setup-nuget@v2
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-          nuget-version: "6.x"
 
       - name: Run Nuget pack
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET Core @ Latest
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.x"
 
       - name: Build solution and generate NuGet package
         run: dotnet build -c Release
@@ -30,7 +30,7 @@ jobs:
         uses: nuget/setup-nuget@v2
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-          nuget-version: "5.x"
+          nuget-version: "6.x"
 
       - name: Run Nuget pack
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup .NET Core @ Latest
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "9.x"
 
       - name: Add the SDK Generator
         run: dotnet tool install SdkGenerator --global

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET Core @ Latest
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.x"
 
       - name: Add the SDK Generator
         run: dotnet tool install SdkGenerator --global


### PR DESCRIPTION
Our workflows started failing after the upgrade to DotNet9.  Let's make our workflows version independent and see if that works.