### PR TITLE
Apply patch for nuget?

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Setup Nuget
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: nuget/setup-nuget@v2
+        uses: nuget/setup-nuget@v2.0.1
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
 


### PR DESCRIPTION
Looks like the Nuget action has changed.  Let's see if updating it fixes the ability to publish.